### PR TITLE
[ Style ] 카테고리 모달 버튼 공통 컴포넌트 구현

### DIFF
--- a/src/components/atoms/CategoryCommonBtn/index.tsx
+++ b/src/components/atoms/CategoryCommonBtn/index.tsx
@@ -1,12 +1,12 @@
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 
-export interface CategoryBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface CategoryBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	variant?: '취소' | '완료';
 	isDisabled?: boolean;
 	children?: ReactNode;
 }
 
-const CategoryCommonBtn = ({ variant, isDisabled, ...props }: CategoryBtnProps) => {
+const CategoryCommonBtn = ({ variant, isDisabled, children, ...props }: CategoryBtnProps) => {
 	const btnVariant = {
 		취소: 'text-white bg-gray-bg-06',
 		완료: 'text-gray-bg-01 bg-mint-02',
@@ -15,14 +15,12 @@ const CategoryCommonBtn = ({ variant, isDisabled, ...props }: CategoryBtnProps) 
 
 	const commonStyle = ' px-[4.8rem] py-[1rem] rounded-[5px] subhead-semibold-18';
 
-	const styledBtn = variant === '취소' ? btnVariant.취소 : isDisabled ? disabledBtn : btnVariant.완료;
+	const styledBtn = isDisabled ? disabledBtn : variant ? btnVariant[variant] : '';
 
 	return (
-		<>
-			<button className={styledBtn + commonStyle} disabled={isDisabled} {...props}>
-				{variant}
-			</button>
-		</>
+		<button className={styledBtn + commonStyle} {...props}>
+			{children}
+		</button>
 	);
 };
 

--- a/src/components/atoms/CategoryCommonBtn/index.tsx
+++ b/src/components/atoms/CategoryCommonBtn/index.tsx
@@ -1,0 +1,29 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export interface CategoryBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	variant?: '취소' | '완료';
+	isDisabled?: boolean;
+	children?: ReactNode;
+}
+
+const CategoryCommonBtn = ({ variant, isDisabled, ...props }: CategoryBtnProps) => {
+	const btnVariant = {
+		취소: 'text-white bg-gray-bg-06',
+		완료: 'text-gray-bg-01 bg-mint-02',
+	};
+	const disabledBtn = 'bg-gray-bg-05 text-gray-04';
+
+	const commonStyle = ' px-[4.8rem] py-[1rem] rounded-[5px] subhead-semibold-18';
+
+	const styledBtn = variant === '취소' ? btnVariant.취소 : isDisabled ? disabledBtn : btnVariant.완료;
+
+	return (
+		<>
+			<button className={styledBtn + commonStyle} disabled={isDisabled} {...props}>
+				{variant}
+			</button>
+		</>
+	);
+};
+
+export default CategoryCommonBtn;

--- a/src/components/atoms/CategoryCommonBtn/index.tsx
+++ b/src/components/atoms/CategoryCommonBtn/index.tsx
@@ -2,8 +2,7 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface CategoryBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	variant?: '취소' | '완료';
-
-	children?: ReactNode;
+	children: ReactNode;
 }
 
 const CategoryCommonBtn = ({ disabled, variant, children, ...props }: CategoryBtnProps) => {

--- a/src/components/atoms/CategoryCommonBtn/index.tsx
+++ b/src/components/atoms/CategoryCommonBtn/index.tsx
@@ -2,11 +2,11 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface CategoryBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	variant?: '취소' | '완료';
-	isDisabled?: boolean;
+
 	children?: ReactNode;
 }
 
-const CategoryCommonBtn = ({ variant, isDisabled, children, ...props }: CategoryBtnProps) => {
+const CategoryCommonBtn = ({ disabled, variant, children, ...props }: CategoryBtnProps) => {
 	const btnVariant = {
 		취소: 'text-white bg-gray-bg-06',
 		완료: 'text-gray-bg-01 bg-mint-02',
@@ -15,10 +15,10 @@ const CategoryCommonBtn = ({ variant, isDisabled, children, ...props }: Category
 
 	const commonStyle = ' px-[4.8rem] py-[1rem] rounded-[5px] subhead-semibold-18';
 
-	const styledBtn = isDisabled ? disabledBtn : variant ? btnVariant[variant] : '';
+	const styledBtn = disabled ? disabledBtn : variant ? btnVariant[variant] : '';
 
 	return (
-		<button className={styledBtn + commonStyle} {...props}>
+		<button className={`${styledBtn} ${commonStyle}`} disabled={disabled} {...props}>
 			{children}
 		</button>
 	);

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,5 +1,9 @@
 const LoginPage = () => {
-	return <div>Login page</div>;
+	return (
+		<>
+			<div>Login Page</div>
+		</>
+	);
 };
 
 export default LoginPage;

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,9 +1,5 @@
 const LoginPage = () => {
-	return (
-		<>
-			<div>Login Page</div>
-		</>
-	);
+	return <div>Login Page</div>;
 };
 
 export default LoginPage;


### PR DESCRIPTION

## 🔥 Related Issues

- close #18 

## ✅ 작업 내용

- [x] 카테고리 모달 버튼 공통 컴포넌트 구현


## 📸 스크린샷 / GI
<img width="153" alt="스크린샷 2024-07-07 오후 6 30 04" src="https://github.com/morib-in/Morib-Client/assets/108131226/8d9025e0-e3a5-469c-918e-55903542bff4">
<img width="159" alt="스크린샷 2024-07-07 오후 6 29 49" src="https://github.com/morib-in/Morib-Client/assets/108131226/37ea525c-502a-41fc-9225-362d5c5d49f7">
<img width="186" alt="스크린샷 2024-07-07 오후 6 29 14" src="https://github.com/morib-in/Morib-Client/assets/108131226/72bd158e-dcdd-4cfb-a7a8-a3c72dc7294b">


## ✍ 궁금한 것
- props로 variant(취소,완료 중 선택)와 isDisabled를 받아서 스타일이 변경되도록 했는데 활성, 비활성 상태와 취소, 완료 버튼의 로직을 한번에 구현하는게 맞는지 궁금해요..!
