### PR TITLE
[Fix] 카테고리 탭 변경하는 부분 상태 관리 수정

### DIFF
--- a/src/components/molecules/CategoryTabSelect/index.tsx
+++ b/src/components/molecules/CategoryTabSelect/index.tsx
@@ -1,18 +1,17 @@
-import { useState } from 'react';
-
 import CategoryTabBtn from '@/components/atoms/CategoryTabBtn';
 
-const CategoryTabSelect = () => {
-	const tabs = [
-		{ id: 1, name: '기존 모립 세트' },
-		{ id: 2, name: '현재 열린 탭' },
-	];
-	const [isSelectedTab, setSelectedTab] = useState(tabs[0].id);
+interface Tabs {
+	id: number;
+	name: string;
+}
 
-	const handleTabChange = (tab: number) => {
-		setSelectedTab(tab);
-	};
+interface TabSelectProps {
+	tabs: Tabs[];
+	handleTabChange: (number: number) => void;
+	isSelectedTab: number;
+}
 
+const CategoryTabSelect = ({ tabs, handleTabChange, isSelectedTab }: TabSelectProps) => {
 	return (
 		<>
 			{tabs.map((tab) => (

--- a/src/constants/tabSelections.ts
+++ b/src/constants/tabSelections.ts
@@ -1,0 +1,4 @@
+export const CATEGORY_MODALTABS = [
+	{ id: 1, name: '기존 모립 세트' },
+	{ id: 2, name: '현재 열린 탭' },
+];


### PR DESCRIPTION

## 🔥 Related Issues

- close #41 

## ✅ 작업 내용

- [ ] 카테고리 탭 변경하는 부분 상태 관리 수정

원래는 CategoryTabSelect에서 탭의 상태를 관리하기로 했으나 드롭다운 버튼에도 변경된 탭의 상태를 넘겨줘야 하므로 상단 컴포넌트인 CategoryModalLeft에서 선택된 탭의 상태관리를 할 수 있도록 수정