### PR TITLE
[ Style ] CategoryModalRight의 header title 컴포넌트 생성

### DIFF
--- a/src/components/atoms/CategoryModalRightTitle/index.tsx
+++ b/src/components/atoms/CategoryModalRightTitle/index.tsx
@@ -1,0 +1,14 @@
+interface CategoryTitle {
+	msetName: string;
+}
+
+const CategoryModalRightTitle = ({ msetName }: CategoryTitle) => {
+	return (
+		<header className="subhead-bold-22 flex p-[1rem]">
+			<h1 className="text-mint-01">{msetName}</h1>
+			<p>의 모립세트</p>
+		</header>
+	);
+};
+
+export default CategoryModalRightTitle;

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,12 +1,5 @@
-import Timer from '@/components/molecules/Timer';
-
 const LoginPage = () => {
-	return (
-		<>
-			Login Page
-			<Timer />
-		</>
-	);
+	return <>Login Page</>;
 };
 
 export default LoginPage;


### PR DESCRIPTION
## 🔥 Related Issues

- close #55 

## ✅ 작업 내용

- [ ] CategoryModalRight의 header title 컴포넌트 생성
```
const CategoryModalRightTitle = ({ msetName }: CategoryTitle) => {
	return (
		<header className="subhead-bold-22 flex p-[1rem]">
			<h1 className="text-mint-01">{msetName}</h1>
			<p>의 모립세트</p>
		</header>
	);
};
```
카테고리를 새로 추가할때 사용자가 입력한 이름을 msetName으로 받아와서 띄우도록 함

## 📸 스크린샷 / GIF / Link
<img width="386" alt="스크린샷 2024-07-11 오후 10 07 39" src="https://github.com/morib-in/Morib-Client/assets/108131226/f5b26a00-9bcd-4bc2-896b-30e273670d89">


