### PR TITLE
[ Style ] 캘린더 토글 및 input창 분리

### DIFF
--- a/src/components/molecules/Calendar/index.tsx
+++ b/src/components/molecules/Calendar/index.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import DatePicker from 'react-datepicker';
 
 import CalendarCustomHeader from '@/components/atoms/CalendarCustomHeader/index';
-import CalendarInput from '@/components/atoms/CalendarInput/index';
-import CategoryInputTitle from '@/components/atoms/CategoryInputTitle';
 import CategoryRoutine from '@/components/atoms/CategoryRoutine/index';
 import CategoryToggle from '@/components/atoms/CategoryToggle';
 
@@ -11,23 +9,34 @@ import { formatCalendarDate } from '@/utils/calendar/index';
 
 import './tailwind-datepicker.css';
 
+interface CalendarProps {
+	onStartDateInput: (date: Date | null) => void;
+	onEndDateInput: (date: Date | null) => void;
+	selectedStartDate: Date | null;
+	selectedEndDate: Date | null;
+	isPeriodOn: boolean;
+	isCalendarOpened: boolean;
+	onPeriodToggle: () => void;
+}
+
 const weekDays: string[] = ['일', '월', '화', '수', '목', '금', '토'];
 
-const Calendar: React.FC = () => {
-	const [selectedStartDate, setSelectedStartDate] = useState<Date | null>(null);
-	const [selectedEndDate, setSelectedEndDate] = useState<Date | null>(null);
-	const [isDateToggleOn, setIsDateToggleOn] = useState(false);
-	const [isPeriodOn, setIsPeriodOn] = useState(false);
+const Calendar = ({
+	onStartDateInput,
+	onEndDateInput,
+	selectedStartDate,
+	selectedEndDate,
+	isPeriodOn,
+	isCalendarOpened,
+	onPeriodToggle,
+}: CalendarProps) => {
 	const [isRoutineOn, setIsRoutineOn] = useState(false);
-	const [isCalendarOpened, setIsCalenderOpened] = useState(false);
-
-	const calendarRef = useRef<HTMLDivElement>(null);
 
 	const defaultDate = new Date();
 
 	const defaultToggleStyle = 'flex justify-between px-[1.75rem]';
 	const calendarStyle =
-		'detail-reg-14 shadow-[0_3px_30px_0_rgba(0, 0, 0, 0.40)] w-[30.3rem] flex-col gap-[2.1rem] rounded-[8px] bg-gray-bg-02 p-[1.4rem] absolute z-50'; // Added absolute positioning and high z-index
+		'detail-reg-14 shadow-[0_3px_30px_0_rgba(0, 0, 0, 0.40)] w-[30.3rem] flex-col gap-[2.1rem] rounded-[8px] bg-gray-bg-02 p-[1.4rem] absolute z-50';
 	const inputStyle = 'body-med-16 h-[3.2rem] w-[27.5rem] rounded-[3px] border-[1px] px-[1rem] py-[0.5rem] ';
 	const calendarInputStyle =
 		'body-med-16 h-[3.2rem] w-[13.2rem] rounded-[3px] border-[1px]  px-[1rem] py-[0.5rem]  bg-gray-bg-02 ';
@@ -66,68 +75,24 @@ const Calendar: React.FC = () => {
 	};
 
 	const handleDateChange = (date: Date | null) => {
-		setSelectedStartDate(date);
+		onStartDateInput(date);
 	};
 
 	const handlePeriodChange = (dates: (Date | null)[]) => {
 		if (dates && dates.length === 2) {
-			setSelectedStartDate(dates[0]);
-			setSelectedEndDate(dates[1]);
+			onStartDateInput(dates[0]);
+			onEndDateInput(dates[1]);
 		} else {
-			setSelectedEndDate(null);
+			onEndDateInput(null);
 		}
 	};
 
-	const handleDateToggle = () => {
-		if (isDateToggleOn === false) setIsCalenderOpened(true);
-		setIsDateToggleOn((prev) => !prev);
-	};
-	const handlePeriodToggle = () => {
-		setIsPeriodOn((prev) => !prev);
-	};
 	const handleRoutineToggle = () => {
 		setIsRoutineOn((prev) => !prev);
 	};
 
-	const handleOpenCalendar = () => {
-		setIsCalenderOpened(true);
-	};
-
-	const handleClickOutside = (event: MouseEvent) => {
-		if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
-			setIsCalenderOpened(false);
-		}
-	};
-
-	useEffect(() => {
-		document.addEventListener('mousedown', handleClickOutside);
-		return () => {
-			document.removeEventListener('mousedown', handleClickOutside);
-		};
-	}, []);
-
-	useEffect(() => {
-		if (isDateToggleOn === false) {
-			setIsCalenderOpened(false);
-		}
-	}, [isCalendarOpened, isDateToggleOn]);
-
 	return (
-		<div ref={calendarRef} className="relative">
-			<div className="ml-[1rem] mt-[1rem] flex items-center gap-[1rem]">
-				<CategoryInputTitle title="날짜" />
-				<div className="mb-[0.6rem]">
-					<CategoryToggle isToggleOn={isDateToggleOn} onToggle={handleDateToggle} />
-				</div>
-			</div>
-			{isDateToggleOn && (
-				<CalendarInput
-					isPeriodOn={isPeriodOn}
-					selectedStartDate={selectedStartDate ?? defaultDate}
-					selectedEndDate={selectedEndDate ?? undefined}
-					onCalendarInputClick={handleOpenCalendar}
-				/>
-			)}
+		<>
 			{isCalendarOpened && (
 				<>
 					<div className={`${calendarStyle}`}>
@@ -139,7 +104,7 @@ const Calendar: React.FC = () => {
 									className={`${inputStyle} ${optionalStyle}`}
 								/>
 								<DatePicker
-									startDate={selectedStartDate !== null ? selectedStartDate : undefined}
+									selected={selectedStartDate !== undefined ? selectedStartDate : null}
 									onChange={handleDateChange}
 									{...commonDatePickerProps}
 								/>
@@ -173,7 +138,7 @@ const Calendar: React.FC = () => {
 						<hr className={divideLineStyle} />
 						<div className={`${defaultToggleStyle}`}>
 							<div className={toggleTxtStyle}>종료 날짜</div>
-							<CategoryToggle isToggleOn={isPeriodOn} onToggle={handlePeriodToggle} />
+							<CategoryToggle isToggleOn={isPeriodOn} onToggle={onPeriodToggle} />
 						</div>
 						<hr className={divideLineStyle} />
 
@@ -187,7 +152,7 @@ const Calendar: React.FC = () => {
 					</div>
 				</>
 			)}
-		</div>
+		</>
 	);
 };
 

--- a/src/pages/HomePage/AddCategoryModal/index.tsx
+++ b/src/pages/HomePage/AddCategoryModal/index.tsx
@@ -1,10 +1,12 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
+import CalendarInput from '@/components/atoms/CalendarInput/index';
 import CategoryCommonBtn from '@/components/atoms/CategoryCommonBtn/index';
 import CategoryCommonTitle from '@/components/atoms/CategoryCommonTitle/index';
+import CategoryInputTitle from '@/components/atoms/CategoryInputTitle/index';
 import CategoryMoribContentPage from '@/components/atoms/CategoryMoribContentPage';
 import CategoryMoribContentUrl from '@/components/atoms/CategoryMoribContentUrl';
-import GetCategoryBtn from '@/components/atoms/GetCategoryBtn/index';
+import CategoryToggle from '@/components/atoms/CategoryToggle/index';
 import Calendar from '@/components/molecules/Calendar/index';
 import CategoryInputMoribName from '@/components/molecules/CategoryInputMoribName/index';
 import CategoryMoribContentSet from '@/components/molecules/CategoryMoribContentSet';
@@ -26,6 +28,13 @@ const AddCategoryModal = () => {
 	const handleNameChange = (newName: string) => {
 		setName(newName);
 	};
+	const [isDateToggleOn, setIsDateToggleOn] = useState(false);
+	const [isPeriodOn, setIsPeriodOn] = useState(false);
+	const [selectedStartDate, setSelectedStartDate] = useState<Date | null>(null);
+	const [selectedEndDate, setSelectedEndDate] = useState<Date | null>(null);
+	const [isCalendarOpened, setIsCalendarOpened] = useState(false);
+
+	const defaultDate = new Date();
 
 	const handleUrlInputChange = (url: string) => {
 		const index = urlInfos.length;
@@ -50,6 +59,48 @@ const AddCategoryModal = () => {
 		categoryRef.current?.close();
 	};
 
+	const handleDateToggle = () => {
+		if (!isDateToggleOn) setIsCalendarOpened(true);
+		setIsDateToggleOn((prev) => !prev);
+	};
+
+	const handlePeriodToggle = () => {
+		setIsPeriodOn((prev) => !prev);
+	};
+
+	const handleStartDateInput = (date: Date | null) => {
+		setSelectedStartDate(date);
+	};
+
+	const handleEndDateInput = (date: Date | null) => {
+		setSelectedEndDate(date);
+	};
+
+	const handleOpenCalendar = () => {
+		setIsCalendarOpened(true);
+	};
+
+	const calendarRef = useRef<HTMLDivElement>(null);
+
+	const handleClickOutside = (event: MouseEvent) => {
+		if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
+			setIsCalendarOpened(false);
+		}
+	};
+
+	useEffect(() => {
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!isDateToggleOn) {
+			setIsCalendarOpened(false);
+		}
+	}, [isCalendarOpened, isDateToggleOn]);
+
 	return (
 		<div>
 			<button type="button" onClick={handleOpenDialog}>
@@ -64,7 +115,33 @@ const AddCategoryModal = () => {
 						<CategoryCommonTitle />
 						<div className="flex-start mt-[1.6rem] inline-flex gap-[4.4rem]">
 							<CategoryInputMoribName onNameChange={handleNameChange} />
-							<Calendar />
+							<div ref={calendarRef}>
+								<div className="ml-[1rem] mt-[1rem] flex items-center gap-[1rem]">
+									<CategoryInputTitle title="날짜" />
+									<div className="mb-[0.6rem]">
+										<CategoryToggle isToggleOn={isDateToggleOn} onToggle={handleDateToggle} />
+									</div>
+								</div>
+								{isDateToggleOn && (
+									<CalendarInput
+										isPeriodOn={isPeriodOn}
+										selectedStartDate={selectedStartDate ?? defaultDate}
+										selectedEndDate={selectedEndDate ?? undefined}
+										onCalendarInputClick={handleOpenCalendar}
+									/>
+								)}
+								{isDateToggleOn && (
+									<Calendar
+										isPeriodOn={isPeriodOn}
+										selectedStartDate={selectedStartDate ?? defaultDate}
+										selectedEndDate={selectedEndDate ?? null}
+										onStartDateInput={handleStartDateInput}
+										onEndDateInput={handleEndDateInput}
+										isCalendarOpened={isCalendarOpened}
+										onPeriodToggle={handlePeriodToggle}
+									/>
+								)}
+							</div>
 						</div>
 
 						<div className="flex flex-col">


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #90

## ✅ 작업 내용

- [ ] 캘린더 토글 및 input창 분리

토글 및 인풋창은 최상단 페이지로 분리했습니다
```
							<div ref={calendarRef}>
								<div className="ml-[1rem] mt-[1rem] flex items-center gap-[1rem]">
									<CategoryInputTitle title="날짜" />
									<div className="mb-[0.6rem]">
										<CategoryToggle isToggleOn={isDateToggleOn} onToggle={handleDateToggle} />
									</div>
								</div>
								{isDateToggleOn && (
									<CalendarInput
										isPeriodOn={isPeriodOn}
										selectedStartDate={selectedStartDate ?? defaultDate}
										selectedEndDate={selectedEndDate ?? undefined}
										onCalendarInputClick={handleOpenCalendar}
									/>
								)}
								{isDateToggleOn && (
									<Calendar
										isPeriodOn={isPeriodOn}
										selectedStartDate={selectedStartDate ?? defaultDate}
										selectedEndDate={selectedEndDate ?? null}
										onStartDateInput={handleStartDateInput}
										onEndDateInput={handleEndDateInput}
										isCalendarOpened={isCalendarOpened}
										onPeriodToggle={handlePeriodToggle}
									/>
								)}
							</div>
```

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/d1345261-c77f-44a9-b322-5aa7d143da1b)

## 📌 이슈 사항

## ✍ 궁금한 것