### PR TITLE
[ feat ] 타이머 뷰 사이드 바 내 할 일 카드 리스트 조회 API 연결

### DIFF
--- a/src/apis/timer/axios/index.ts
+++ b/src/apis/timer/axios/index.ts
@@ -1,0 +1,12 @@
+import { nonAuthClient } from '@/apis/client';
+
+const TIMER_URL = {
+	GET_TODOLIST: 'api/v1/timer/todo-card',
+};
+
+export const getTodoList = async (targetDate: string) => {
+	const { data } = await nonAuthClient.get(TIMER_URL.GET_TODOLIST, {
+		params: { targetDate: targetDate },
+	});
+	return data;
+};

--- a/src/apis/timer/queries/index.ts
+++ b/src/apis/timer/queries/index.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getTodoList } from '../axios';
+
+export const useGetTodoList = (targetDate: string) => {
+	return useQuery({
+		queryKey: ['todo', targetDate],
+		queryFn: () => getTodoList(targetDate),
+	});
+};

--- a/src/components/atoms/AccumulatedTime/index.tsx
+++ b/src/components/atoms/AccumulatedTime/index.tsx
@@ -2,11 +2,11 @@ import useTimerCount from '@/hooks/useTimerCount';
 
 interface AccumulatedTimeProps {
 	isPlaying: boolean;
-	accumulatedTime: number;
+	totalTimeOfToday: number;
 }
 
-const AccumulatedTime = ({ isPlaying, accumulatedTime }: AccumulatedTimeProps) => {
-	const timer = useTimerCount({ isPlaying, previousTime: accumulatedTime });
+const AccumulatedTime = ({ isPlaying, totalTimeOfToday }: AccumulatedTimeProps) => {
+	const timer = useTimerCount({ isPlaying, previousTime: totalTimeOfToday });
 
 	const hours = Math.floor(timer / 3600);
 	const minutes = Math.floor((timer % 3600) / 60);

--- a/src/components/atoms/TodoBox/index.tsx
+++ b/src/components/atoms/TodoBox/index.tsx
@@ -18,6 +18,7 @@ interface TodoBoxProps {
 	isComplete: boolean;
 	isSelected?: boolean;
 	selectedNumber?: number;
+	onClick: () => void;
 }
 
 const TodoBox = ({
@@ -28,6 +29,7 @@ const TodoBox = ({
 	isComplete,
 	isSelected = true,
 	selectedNumber = 1,
+	onClick,
 }: TodoBoxProps) => {
 	const formattedTime = formatSeconds(targetTime);
 	const formattedstartDate = startDate.replace(/-/g, '.');
@@ -41,10 +43,10 @@ const TodoBox = ({
 
 	const selectedStyle = isSelected ? ' border-[0.2rem] border-mint-01' : '';
 
-	//추후 SVG 버튼 컴포넌트로 만들것임
 	return (
 		<div
 			className={`group relative mt-[1rem] h-[9.6rem] w-[36.6rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle}`}
+			onClick={onClick}
 		>
 			<div className="flex flex-col justify-center">
 				<div className="flex items-center justify-between">

--- a/src/components/atoms/TodoBox/index.tsx
+++ b/src/components/atoms/TodoBox/index.tsx
@@ -11,30 +11,33 @@ import MeatBall from '@/assets/svgs/todo_meatball_default.svg?react';
 import SVGBtn from '../SVGBtn';
 
 interface TodoBoxProps {
-	title: string;
-	date: string;
-	accumulatedTime: number;
-	isCompleted?: boolean;
+	name: string;
+	startDate: string;
+	endDate: string | null;
+	targetTime: number;
+	isComplete: boolean;
 	isSelected?: boolean;
 	selectedNumber?: number;
 }
 
 const TodoBox = ({
-	title,
-	date,
-	accumulatedTime,
-	isCompleted = false,
+	name,
+	startDate,
+	endDate,
+	targetTime,
+	isComplete,
 	isSelected = true,
 	selectedNumber = 1,
 }: TodoBoxProps) => {
-	const formattedTime = formatSeconds(accumulatedTime);
-	const formattedDate = date.replace(/-/g, '.');
+	const formattedTime = formatSeconds(targetTime);
+	const formattedstartDate = startDate.replace(/-/g, '.');
+	const formattedendDate = endDate ? endDate.replace(/-/g, '.') : '';
 
-	const titleStyle = isCompleted ? 'line-through' : '';
-	const CheckBoxIcon = isCompleted ? <CheckBoxFillIcon /> : <CheckBoxBlankIcon />;
+	const nameStyle = isComplete ? 'line-through' : '';
+	const CheckBoxIcon = isComplete ? <CheckBoxFillIcon /> : <CheckBoxBlankIcon />;
 
-	const TimeIcon = accumulatedTime ? <TimeFillIcon /> : <TimeLineIcon />;
-	const timeTextClass = accumulatedTime ? 'text-mint-01' : 'text-gray-04';
+	const TimeIcon = targetTime ? <TimeFillIcon /> : <TimeLineIcon />;
+	const timeTextClass = targetTime ? 'text-mint-01' : 'text-gray-04';
 
 	const selectedStyle = isSelected ? ' border-[0.2rem] border-mint-01' : '';
 
@@ -47,7 +50,7 @@ const TodoBox = ({
 				<div className="flex items-center justify-between">
 					<div className="flex items-center gap-[0.6rem]">
 						<SVGBtn>{CheckBoxIcon}</SVGBtn>
-						<h3 className={`body-semibold-16 + mt-[0.42rem] text-white ${titleStyle}`}>{title}</h3>
+						<h3 className={`body-semibold-16 + mt-[0.42rem] text-white ${nameStyle}`}>{name}</h3>
 					</div>
 					<SVGBtn>
 						<MeatBall className="opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
@@ -56,7 +59,9 @@ const TodoBox = ({
 				<div className="ml-[0.8rem] mt-[0.7rem] flex flex-col gap-[0.2rem]">
 					<button className="flex items-center gap-[0.6rem]">
 						<ButtonCalendarIcon />
-						<p className="detail-reg-12 mt-[0.3rem] text-gray-04">{formattedDate}</p>
+						<p className="detail-reg-12 mt-[0.3rem] text-gray-04">
+							{formattedstartDate}~{formattedendDate}
+						</p>
 					</button>
 
 					<div className="flex items-center gap-[0.6rem]">

--- a/src/components/molecules/Timer/index.tsx
+++ b/src/components/molecules/Timer/index.tsx
@@ -9,11 +9,16 @@ import useTimerCount from '@/hooks/useTimerCount';
 
 import InnerCircleIcon from '@/assets/svgs/elipse.svg?react';
 
-const Timer = () => {
+interface TaskTotalTimeProps {
+	totalTimeOfToday: number;
+	targetTime: number;
+}
+
+const Timer = ({ totalTimeOfToday, targetTime }: TaskTotalTimeProps) => {
 	const [isPlaying, setIsPlaying] = useState(false);
-	const previousTime = 20000; //임의로 10000을 넣어 놓음
-	const timer = useTimerCount({ isPlaying, previousTime });
-	const accumulatedTime = 20000; //임의로 30000을 넣어 놓음
+
+	const timer = useTimerCount({ isPlaying, previousTime: targetTime });
+	const accumulatedTime = totalTimeOfToday || 0;
 
 	const handlePlayPauseToggle = () => {
 		setIsPlaying((prevState) => !prevState);
@@ -25,7 +30,7 @@ const Timer = () => {
 			<InnerCircleIcon className="absolute" />
 			<div className="absolute flex h-[22rem] w-[27.1rem] flex-col items-center justify-center">
 				<div className="flex flex-col items-center justify-center">
-					<AccumulatedTime isPlaying={isPlaying} accumulatedTime={accumulatedTime} />
+					<AccumulatedTime isPlaying={isPlaying} totalTimeOfToday={accumulatedTime} />
 					<TaskTime isPlaying={isPlaying} timer={timer} />
 				</div>
 				<div>

--- a/src/components/molecules/TimerSideBar/index.tsx
+++ b/src/components/molecules/TimerSideBar/index.tsx
@@ -6,21 +6,22 @@ import useCloseSidebar from '@/hooks/useCloseSideBar';
 
 import BtnListIcon from '@/assets/svgs/btn_list.svg?react';
 
-import { todoData } from '@/mocks/homeData';
-
 interface Todo {
 	id: number;
-	title: string;
-	date: string;
-	accumulatedTime: number;
+	name: string;
+	startDate: string;
+	endDate: string | null;
+	targetTime: number;
+	isComplete: boolean;
 }
 interface CategoryBoxProps {
-	completedTodos?: Todo[];
-	ongoingTodos?: Todo[];
+	completedTodos: Todo[];
+	ongoingTodos: Todo[];
 	toggleSidebar: () => void;
 }
-const TimerSideBar = ({ ongoingTodos = todoData, completedTodos = todoData, toggleSidebar }: CategoryBoxProps) => {
+const TimerSideBar = ({ ongoingTodos = [], completedTodos = [], toggleSidebar }: CategoryBoxProps) => {
 	const { animate, handleClose } = useCloseSidebar(toggleSidebar);
+
 	return (
 		<div
 			className={`flex h-[108rem] w-[40.2rem] transform flex-col rounded-bl-[16px] rounded-tl-[16px] bg-gray-bg-03 pl-[1.8rem] transition-transform duration-300 ${animate ? 'translate-x-0' : 'translate-x-full'}`}
@@ -33,12 +34,27 @@ const TimerSideBar = ({ ongoingTodos = todoData, completedTodos = todoData, togg
 				</button>
 			</div>
 			<div className="h-[82.6rem] overflow-auto pb-[2rem] pt-[1rem]">
-				{ongoingTodos.map(({ id, title, date, accumulatedTime }) => (
-					<TodoBox key={id} title={title} date={date} accumulatedTime={accumulatedTime} isCompleted={false} />
+				{ongoingTodos.map(({ name, startDate, endDate, targetTime, isComplete }) => (
+					<TodoBox
+						key={name}
+						name={name}
+						startDate={startDate}
+						endDate={endDate}
+						targetTime={targetTime}
+						isComplete={isComplete}
+					/>
 				))}
 				<TodoToggleBtn isCompleted={false} isToggled={false}>
-					{completedTodos.map(({ id, title, date, accumulatedTime }) => (
-						<TodoBox key={id} title={title} date={date} accumulatedTime={accumulatedTime} isCompleted={true} />
+					{completedTodos.map(({ name, startDate, endDate, targetTime, isComplete }) => (
+						<TodoBox
+							// Todo: 서버와 협의 후 id 값을 받아서 지정해주기(name 등은 중복될 수 있음)
+							key={name}
+							name={name}
+							startDate={startDate}
+							endDate={endDate}
+							targetTime={targetTime}
+							isComplete={isComplete}
+						/>
 					))}
 				</TodoToggleBtn>
 			</div>
@@ -49,4 +65,5 @@ const TimerSideBar = ({ ongoingTodos = todoData, completedTodos = todoData, togg
 		</div>
 	);
 };
+
 export default TimerSideBar;

--- a/src/components/molecules/TimerSideBar/index.tsx
+++ b/src/components/molecules/TimerSideBar/index.tsx
@@ -18,8 +18,16 @@ interface CategoryBoxProps {
 	completedTodos: Todo[];
 	ongoingTodos: Todo[];
 	toggleSidebar: () => void;
+	setTargetTime: (time: number) => void;
+	setTargetName: (name: string) => void;
 }
-const TimerSideBar = ({ ongoingTodos = [], completedTodos = [], toggleSidebar }: CategoryBoxProps) => {
+const TimerSideBar = ({
+	ongoingTodos = [],
+	completedTodos = [],
+	toggleSidebar,
+	setTargetTime,
+	setTargetName,
+}: CategoryBoxProps) => {
 	const { animate, handleClose } = useCloseSidebar(toggleSidebar);
 
 	return (
@@ -34,26 +42,25 @@ const TimerSideBar = ({ ongoingTodos = [], completedTodos = [], toggleSidebar }:
 				</button>
 			</div>
 			<div className="h-[82.6rem] overflow-auto pb-[2rem] pt-[1rem]">
-				{ongoingTodos.map(({ name, startDate, endDate, targetTime, isComplete }) => (
+				{ongoingTodos.map((todo) => (
 					<TodoBox
-						key={name}
-						name={name}
-						startDate={startDate}
-						endDate={endDate}
-						targetTime={targetTime}
-						isComplete={isComplete}
+						key={todo.id}
+						{...todo}
+						onClick={() => {
+							setTargetTime(todo.targetTime);
+							setTargetName(todo.name);
+						}}
 					/>
 				))}
 				<TodoToggleBtn isCompleted={false} isToggled={false}>
-					{completedTodos.map(({ name, startDate, endDate, targetTime, isComplete }) => (
+					{completedTodos.map((todo) => (
 						<TodoBox
-							// Todo: 서버와 협의 후 id 값을 받아서 지정해주기(name 등은 중복될 수 있음)
-							key={name}
-							name={name}
-							startDate={startDate}
-							endDate={endDate}
-							targetTime={targetTime}
-							isComplete={isComplete}
+							key={todo.id}
+							{...todo}
+							onClick={() => {
+								setTargetTime(todo.targetTime);
+								setTargetName(todo.name);
+							}}
 						/>
 					))}
 				</TodoToggleBtn>

--- a/src/components/molecules/TimerTitle/index.tsx
+++ b/src/components/molecules/TimerTitle/index.tsx
@@ -1,10 +1,14 @@
 import CategoryTitle from './CategoryTitle';
 import TodoTitle from './TodoTitle';
 
-const TimerTitle = () => {
+interface titleNameProps {
+	targetName: string;
+}
+
+const TimerTitle = ({ targetName }: titleNameProps) => {
 	return (
 		<div className="mt-[8.6rem] flex flex-col items-center gap-[1rem]">
-			<TodoTitle title="스톱워치 와프 그리기" />
+			<TodoTitle title={targetName} />
 			<CategoryTitle title="모립 프로젝트" />
 		</div>
 	);

--- a/src/hooks/useTimerCount.ts
+++ b/src/hooks/useTimerCount.ts
@@ -9,6 +9,10 @@ const useTimerCount = ({ isPlaying, previousTime }: UseTimerCountProps) => {
 	const [timer, setTimer] = useState(previousTime);
 
 	useEffect(() => {
+		setTimer(previousTime);
+	}, [previousTime]);
+
+	useEffect(() => {
 		let timerIntervalId: ReturnType<typeof setInterval>;
 
 		if (isPlaying) {

--- a/src/pages/HomePage/AddCategoryModal/index.tsx
+++ b/src/pages/HomePage/AddCategoryModal/index.tsx
@@ -4,7 +4,7 @@ import CategoryCommonBtn from '@/components/atoms/CategoryCommonBtn/index';
 import CategoryCommonTitle from '@/components/atoms/CategoryCommonTitle/index';
 import CategoryMoribContentPage from '@/components/atoms/CategoryMoribContentPage';
 import CategoryMoribContentUrl from '@/components/atoms/CategoryMoribContentUrl';
-import GetCategoryBtn from '@/components/atoms/GetCategoryBtn/index';
+import GetCategoryBtn from '@/components/atoms/GetCategoryBtn';
 import Calendar from '@/components/molecules/Calendar/index';
 import CategoryInputMoribName from '@/components/molecules/CategoryInputMoribName/index';
 import CategoryMoribContentSet from '@/components/molecules/CategoryMoribContentSet';

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import FriendInfoCarousel from '@/components/molecules/FriendInfoCarousel';
 import Timer from '@/components/molecules/Timer';
 import TimerSideBar from '@/components/molecules/TimerSideBar';
@@ -15,7 +17,18 @@ const TimerPage = () => {
 	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
 	const { data: todosData, isLoading, error } = useGetTodoList('2024-07-15');
 
-	const todos = todosData?.data.task || [];
+	const todos = useMemo(() => todosData?.data.task || [], [todosData]);
+	const tasktotaltime = todosData?.data || [];
+
+	const [targetTime, setTargetTime] = useState(0);
+	const [targetName, setTargetName] = useState('');
+
+	useEffect(() => {
+		if (todos.length > 0) {
+			setTargetTime(todos[0].targetTime);
+			setTargetName(todos[0].name);
+		}
+	}, [todos]);
 
 	if (isLoading) return <div>Loading...</div>;
 	if (error) return <div>Error loading todos</div>;
@@ -27,8 +40,8 @@ const TimerPage = () => {
 					<TimerSideBox />
 				</div>
 				<div className="ml-[56.6rem] mt-[-0.8rem]">
-					<TimerTitle />
-					<Timer />
+					<TimerTitle targetName={targetName} />
+					<Timer totalTimeOfToday={tasktotaltime.totalTimeOfToday} targetTime={targetTime} />
 					<FriendInfoCarousel />
 				</div>
 				<button
@@ -40,7 +53,13 @@ const TimerPage = () => {
 				{isSidebarOpen && (
 					<div className="absolute inset-0 z-10 bg-dim">
 						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-							<TimerSideBar ongoingTodos={todos} completedTodos={todos} toggleSidebar={toggleSidebar} />
+							<TimerSideBar
+								ongoingTodos={todos}
+								completedTodos={todos}
+								toggleSidebar={toggleSidebar}
+								setTargetTime={setTargetTime}
+								setTargetName={setTargetName}
+							/>
 						</div>
 					</div>
 				)}

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -7,10 +7,18 @@ import TimerPageTemplates from '@/components/templates/TimerPageTemplates';
 
 import useToggleSidebar from '@/hooks/useToggleSideBar';
 
+import { useGetTodoList } from '@/apis/timer/queries';
+
 import HamburgerIcon from '@/assets/svgs/btn_hamburger.svg?react';
 
 const TimerPage = () => {
 	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
+	const { data: todosData, isLoading, error } = useGetTodoList('2024-07-15');
+
+	const todos = todosData?.data.task || [];
+
+	if (isLoading) return <div>Loading...</div>;
+	if (error) return <div>Error loading todos</div>;
 
 	return (
 		<TimerPageTemplates>
@@ -32,7 +40,7 @@ const TimerPage = () => {
 				{isSidebarOpen && (
 					<div className="absolute inset-0 z-10 bg-dim">
 						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-							<TimerSideBar toggleSidebar={toggleSidebar} />
+							<TimerSideBar ongoingTodos={todos} completedTodos={todos} toggleSidebar={toggleSidebar} />
 						</div>
 					</div>
 				)}
@@ -40,4 +48,5 @@ const TimerPage = () => {
 		</TimerPageTemplates>
 	);
 };
+
 export default TimerPage;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #92

## ✅ 작업 내용

- [ ] 타이머 뷰 사이드 바 내 할 일 카드 리스트 조회 API 연결
- [ ] 테스크 클릭시 해당 테스크 정보 타이머에 업데이트

## 📸 스크린샷 / GIF / Link
<img width="269" alt="스크린샷 2024-07-16 오후 5 53 23" src="https://github.com/user-attachments/assets/415d7b84-c5de-40fb-bd0b-01ec334a1c38">

https://github.com/user-attachments/assets/af8f9346-e3a6-4676-ba1a-3cd04f15dc7a



## 📌 이슈 사항
<img width="425" alt="스크린샷 2024-07-16 오후 5 17 45" src="https://github.com/user-attachments/assets/7cfd26e9-f6cb-4d8e-8d3d-f5e387330a83">

key값을 지정해주지 않아 Waring이 발생했다

<img width="453" alt="스크린샷 2024-07-16 오후 5 30 14" src="https://github.com/user-attachments/assets/7968daff-89ea-42ac-a2c7-3422cbd53e12">
ResponseBody를 확인해보니 id값을 함께 보내주지 않아서 고유 키 값을 지정해주지 못하였기 때문이었다

```typescript
{ongoingTodos.map(({ name, startDate, endDate, targetTime, isComplete }) => (
					<TodoBox
						key={name}
						name={name}
						startDate={startDate}
						endDate={endDate}
						targetTime={targetTime}
						isComplete={isComplete}
					/>
				))}
```
임의로 key값을 name으로 지정해주었습니다. 같은 카테고리 내에서 테스크 이름이 동일한 중복 테스크를 생성할 수 있기 때문에 추후에 서버와 협의해서 id값도 ResponseBody에 담아서 보내도록 해주어야할 것 같습니다.

테스크를 클릭 할 때마다, 해당 테스크의 name과  targetTime을 업데이트 할 수 있도록 하였습니다. 그러나, ResponseBody에 카테고리 이름은 보내주고 있지 않기 때문에 이부분도 추후에 서버에서 수정해주면 처리해야 될 것 같습니다.

타어미의 progress circle보다 흰색 동그라미 부분이 먼저 update되어 화면상 어색해 보이는 문제가 있습니다. 이 부분도 추후에 수정하도록 하겠습니다!

## ✍ 궁금한 것