### PR TITLE
[ Feat ] 타이머 뷰 사이드 바 내 할 일 카드 리스트 조회 API 연결 추가 구현

### DIFF
--- a/src/components/molecules/TimerTitle/index.tsx
+++ b/src/components/molecules/TimerTitle/index.tsx
@@ -3,13 +3,14 @@ import TodoTitle from './TodoTitle';
 
 interface titleNameProps {
 	targetName: string;
+	targetCategoryName: string;
 }
 
-const TimerTitle = ({ targetName }: titleNameProps) => {
+const TimerTitle = ({ targetName, targetCategoryName }: titleNameProps) => {
 	return (
 		<div className="mt-[8.6rem] flex flex-col items-center gap-[1rem]">
 			<TodoTitle title={targetName} />
-			<CategoryTitle title="모립 프로젝트" />
+			<CategoryTitle title={targetCategoryName} />
 		</div>
 	);
 };

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -22,11 +22,15 @@ const TimerPage = () => {
 
 	const [targetTime, setTargetTime] = useState(0);
 	const [targetName, setTargetName] = useState('');
+	const [targetCategoryName, setTargetCategoryName] = useState('');
+	const [id, setId] = useState(null);
 
 	useEffect(() => {
 		if (todos.length > 0) {
 			setTargetTime(todos[0].targetTime);
 			setTargetName(todos[0].name);
+			setTargetCategoryName(todos[0].categoryName);
+			setId(todos[0].id);
 		}
 	}, [todos]);
 
@@ -40,7 +44,7 @@ const TimerPage = () => {
 					<TimerSideBox />
 				</div>
 				<div className="ml-[56.6rem] mt-[-0.8rem]">
-					<TimerTitle targetName={targetName} />
+					<TimerTitle targetName={targetName} targetCategoryName={targetCategoryName} />
 					<Timer totalTimeOfToday={tasktotaltime.totalTimeOfToday} targetTime={targetTime} />
 					<FriendInfoCarousel />
 				</div>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 내용

- [x] 카테고리 타이틀 넘겨주기
- [x] id 값 상태로 관리하도록 구현

## 📸 스크린샷 / GIF / Link
<img width="1017" alt="스크린샷 2024-07-17 오전 1 43 35" src="https://github.com/user-attachments/assets/92a1cfcf-904f-4a0c-bc56-ce85d2f4c571">

## 📌 이슈 사항
build시 선언되었지만 읽히지 않는 다는 오류 제외하고 없는 것 확인 했습니다

## ✍ 궁금한 것