### PR TITLE
[ Feat ] url로 탭 이름 가져오기

### DIFF
--- a/src/apis/tasks/axios/index.tsx
+++ b/src/apis/tasks/axios/index.tsx
@@ -14,9 +14,17 @@ interface CategoryDataProps {
 
 const TASK_URL = {
 	POST_CATEGORY: 'api/v1/categories',
+	GET_TABNAME: 'api/v1/fetch-title',
 };
 
 export const postCategory = async (categoryData: CategoryDataProps) => {
 	const { data } = await nonAuthClient.post(TASK_URL.POST_CATEGORY, categoryData);
+	return data;
+};
+
+export const getTabName = async (requestUrl: string) => {
+	const { data } = await nonAuthClient.get(TASK_URL.GET_TABNAME, {
+		params: { requestUrl: requestUrl },
+	});
 	return data;
 };

--- a/src/apis/tasks/queries/index.tsx
+++ b/src/apis/tasks/queries/index.tsx
@@ -1,6 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { postCategory } from '@/apis/tasks/axios/index';
+import { getTabName, postCategory } from '@/apis/tasks/axios/index';
 
 interface MSet {
 	name: string;
@@ -17,5 +17,13 @@ interface CategoryDataProps {
 export const usePostCategory = () => {
 	return useMutation({
 		mutationFn: (categoryData: CategoryDataProps) => postCategory(categoryData),
+	});
+};
+
+export const useGetTabName = (requestUrl: string) => {
+	return useQuery({
+		queryKey: ['tabName', requestUrl],
+		queryFn: () => getTabName(requestUrl),
+		enabled: requestUrl !== '',
 	});
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #104

## ✅ 작업 내용

- [x] url로 탭 이름 가져오기

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/8b854f83-f5fc-42bb-89de-01ba15868221

![image](https://github.com/user-attachments/assets/cc137f8e-f629-4bb1-bc50-705b9c193494)
![image](https://github.com/user-attachments/assets/386594f1-9f33-40e5-b066-8336bca12948)

## 📌 이슈 사항
![image](https://github.com/user-attachments/assets/965ed93a-a75f-4acc-a215-134a6f2613aa)

url 입력 후 enter을 누르기 직전까지 계속해서 useQuery get을 요청하는 네트워크 에러 발생… ㅠ.ㅠ

## 해결 방안

### Query Options
- enabled (boolean)
:   `enabled` 는 쿼리가 자동으로 실행되지 않게 설정하는 옵션

```jsx
export const useGetTabName = (requestUrl: string) => {
	return useQuery({
		queryKey: ['tabName', requestUrl],
		queryFn: () => getTabName(requestUrl), 
		/// 요 부분 enabled 속성 추가
		enabled: requestUrl !== '',
	});
};
```

## ✍ 궁금한 것