### PR TITLE
[ Feat ] 카테고리 모달 뷰 관련 API 연결

### DIFF
--- a/src/apis/modal/axios/index.ts
+++ b/src/apis/modal/axios/index.ts
@@ -21,7 +21,7 @@ export const categoryLists = async () => {
 };
 
 export const getMsets = async (categoryId: number | null) => {
-	const { data } = await nonAuthClient.get(CATEGORY_URL.MSETS_FROM_CATEGORY, {
+	const { data } = await nonAuthClient.get(`${CATEGORY_URL.MSETS_FROM_CATEGORY}${categoryId}`, {
 		params: {
 			categoryId: categoryId,
 		},

--- a/src/apis/modal/axios/index.ts
+++ b/src/apis/modal/axios/index.ts
@@ -1,13 +1,13 @@
 import { nonAuthClient } from '@/apis/client';
 
 const CATEGORY_URL = {
-	TAB_NAME: 'api/v1/fetch-title?',
+	TAB_NAME: 'api/v1/fetch-title',
 	CATEGORIES_LIST: 'api/v1/categories',
 	MSETS_FROM_CATEGORY: 'api/v1/mset/categories/',
 };
 
 export const getTabName = async (requestUrl: string) => {
-	const { data } = await nonAuthClient.get(`${CATEGORY_URL.TAB_NAME}requestUrl=${requestUrl}`, {
+	const { data } = await nonAuthClient.get(CATEGORY_URL.TAB_NAME, {
 		params: {
 			requestUrl: requestUrl,
 		},

--- a/src/apis/modal/axios/index.ts
+++ b/src/apis/modal/axios/index.ts
@@ -1,0 +1,30 @@
+import { nonAuthClient } from '@/apis/client';
+
+const CATEGORY_URL = {
+	TAB_NAME: 'api/v1/fetch-title?',
+	CATEGORIES_LIST: 'api/v1/categories',
+	MSETS_FROM_CATEGORY: 'api/v1/mset/categories/',
+};
+
+export const getTabName = async (requestUrl: string) => {
+	const { data } = await nonAuthClient.get(`${CATEGORY_URL.TAB_NAME}requestUrl=${requestUrl}`, {
+		params: {
+			requestUrl: requestUrl,
+		},
+	});
+	return data;
+};
+
+export const categoryLists = async () => {
+	const { data } = await nonAuthClient.get(CATEGORY_URL.CATEGORIES_LIST);
+	return data;
+};
+
+export const getMsets = async (categoryId: number | null) => {
+	const { data } = await nonAuthClient.get(CATEGORY_URL.MSETS_FROM_CATEGORY, {
+		params: {
+			categoryId: categoryId,
+		},
+	});
+	return data;
+};

--- a/src/apis/modal/queries/index.ts
+++ b/src/apis/modal/queries/index.ts
@@ -6,6 +6,7 @@ export const useGetTabName = (requestUrl: string) => {
 	return useQuery({
 		queryKey: ['UrlTabName', requestUrl],
 		queryFn: () => getTabName(requestUrl),
+		enabled: requestUrl !== '',
 	});
 };
 

--- a/src/apis/modal/queries/index.ts
+++ b/src/apis/modal/queries/index.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { categoryLists, getMsets, getTabName } from '@/apis/modal/axios';
+
+export const useGetTabName = (requestUrl: string) => {
+	return useQuery({
+		queryKey: ['UrlTabName', requestUrl],
+		queryFn: () => getTabName(requestUrl),
+	});
+};
+
+export const useCategoryLists = () => {
+	return useQuery({
+		queryKey: ['categories'],
+		queryFn: categoryLists,
+	});
+};
+
+export const useGetMsets = (categoryId: number | null) => {
+	return useQuery({
+		queryKey: ['msets', categoryId],
+		queryFn: () => getMsets(categoryId),
+	});
+};

--- a/src/components/atoms/CategoryMoribContentPage/index.tsx
+++ b/src/components/atoms/CategoryMoribContentPage/index.tsx
@@ -1,6 +1,8 @@
+import { useGetTabName } from '@/apis/modal/queries';
+
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 
@@ -10,6 +12,11 @@ interface CategoryMoribContentProps {
 }
 
 const CategoryMoribContentPage = ({ urlInfo, variant }: CategoryMoribContentProps) => {
+	const { data: tabNames, error, isLoading } = useGetTabName(urlInfo.url);
+	if (isLoading) return <div>Loading...</div>;
+	if (error) return <div>Error loading</div>;
+	const domain = tabNames?.data.tabName;
+
 	const sizeVariant = {
 		basic: {
 			pageWidth: 'w-[22.8rem]',
@@ -24,9 +31,7 @@ const CategoryMoribContentPage = ({ urlInfo, variant }: CategoryMoribContentProp
 		<td className="flex items-center">
 			<div className={`my-[0.1rem] flex h-[2.2rem] items-center`}>
 				<img src={urlInfo.favicon} alt="favicon" className="my-[0.1rem] mr-[1.2rem] h-[2rem] w-[2rem]" />
-				<div className={`body-reg-16 my-[0.05rem] truncate text-white ${sizeVariant[variant].pageWidth}`}>
-					{urlInfo.domain}
-				</div>
+				<div className={`body-reg-16 my-[0.05rem] truncate text-white ${sizeVariant[variant].pageWidth}`}>{domain}</div>
 			</div>
 		</td>
 	);

--- a/src/components/atoms/CategoryMoribContentUrl/index.tsx
+++ b/src/components/atoms/CategoryMoribContentUrl/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 

--- a/src/components/atoms/CategoryUrlInput/index.tsx
+++ b/src/components/atoms/CategoryUrlInput/index.tsx
@@ -50,7 +50,8 @@ const CategoryUrlInput = ({ variant = 'basic', onUrlInputChange, selectedInfo }:
 	};
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setUrl(e.target.value);
+		const userInput = e.target.value;
+		setUrl(userInput);
 		setIsUrlValidated(null);
 		setErrorMessage('');
 	};

--- a/src/components/atoms/CategoryUrlInput/index.tsx
+++ b/src/components/atoms/CategoryUrlInput/index.tsx
@@ -6,7 +6,7 @@ import AlertIcon from '@/assets/svgs/ic_description.svg?react';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 

--- a/src/components/molecules/CategoryDropdown/index.tsx
+++ b/src/components/molecules/CategoryDropdown/index.tsx
@@ -5,6 +5,7 @@ import DropdownOptionsBtn from '@/components/atoms/DropdownOptionsBtn';
 
 interface DropdownBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	optionData: Category[];
+	handleOptionId: (id: number) => void;
 }
 
 interface Category {
@@ -14,7 +15,7 @@ interface Category {
 	endDate: string;
 }
 
-const CategoryDropdown = ({ disabled, optionData }: DropdownBtnProps) => {
+const CategoryDropdown = ({ disabled, handleOptionId, optionData }: DropdownBtnProps) => {
 	const [isClicked, setIsClicked] = useState(false);
 	const [selectedOption, setSelectedOption] = useState('카테고리 추가');
 
@@ -22,6 +23,7 @@ const CategoryDropdown = ({ disabled, optionData }: DropdownBtnProps) => {
 		setSelectedOption(name);
 		setIsClicked(false);
 	};
+
 	const handleBtnClicked = () => {
 		setIsClicked((prev) => !prev);
 	};
@@ -45,6 +47,7 @@ const CategoryDropdown = ({ disabled, optionData }: DropdownBtnProps) => {
 								<DropdownOptionsBtn
 									onClick={() => {
 										handleOptionClick(item.name);
+										handleOptionId(item.id);
 									}}
 								>
 									{item.name}

--- a/src/components/molecules/CategoryDropdown/index.tsx
+++ b/src/components/molecules/CategoryDropdown/index.tsx
@@ -4,16 +4,14 @@ import CategoryDropdownBtn from '@/components/atoms/CategoryDropdownBtn';
 import DropdownOptionsBtn from '@/components/atoms/DropdownOptionsBtn';
 
 interface DropdownBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-	optionData: OptionData[];
+	optionData: Category[];
 }
 
 interface Category {
 	id: number;
 	name: string;
-}
-
-interface OptionData {
-	category: Category;
+	startDate: string;
+	endDate: string;
 }
 
 const CategoryDropdown = ({ disabled, optionData }: DropdownBtnProps) => {
@@ -41,15 +39,15 @@ const CategoryDropdown = ({ disabled, optionData }: DropdownBtnProps) => {
 					{optionData?.map((item) => {
 						return (
 							<li
-								key={item.category.id}
+								key={item.id}
 								className="subhead-med-18 flex h-[4.6rem] w-[27.2rem] flex-row items-center border-none"
 							>
 								<DropdownOptionsBtn
 									onClick={() => {
-										handleOptionClick(item.category.name);
+										handleOptionClick(item.name);
 									}}
 								>
-									{item.category.name}
+									{item.name}
 								</DropdownOptionsBtn>
 							</li>
 						);

--- a/src/components/molecules/CategoryModalLeft/index.tsx
+++ b/src/components/molecules/CategoryModalLeft/index.tsx
@@ -13,7 +13,7 @@ import AddBtn from '@/assets/svgs/add_btn.svg?react';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 
@@ -50,8 +50,9 @@ const CategoryModalLeft = ({ optionData, handleSelectedInfo, handleOptionId, mse
 	const urlInfos = msetsList.map((item) => ({
 		url: item.url,
 		favicon: `https://www.google.com/s2/favicons?domain=${item.url}`,
-		domain: item.name,
 	}));
+
+	console.log('urlInfos', urlInfos);
 
 	return (
 		<div className="h-[80rem] w-[68.8rem] rounded-l-[10px] bg-gray-bg-04 py-[2.8rem] pl-[4.4rem] pr-[4.3rem]">

--- a/src/components/molecules/CategoryModalLeft/index.tsx
+++ b/src/components/molecules/CategoryModalLeft/index.tsx
@@ -19,17 +19,15 @@ interface UrlInfo {
 	favicon: string;
 }
 interface ModalProps {
-	optionData: OptionData[];
+	optionData: Category[];
 	handleSelectedInfo: (url: UrlInfo) => void;
 }
 
 interface Category {
 	id: number;
 	name: string;
-}
-
-interface OptionData {
-	category: Category;
+	startDate: string;
+	endDate: string;
 }
 
 const CategoryModalLeft = ({ optionData, handleSelectedInfo }: ModalProps) => {

--- a/src/components/molecules/CategoryModalLeft/index.tsx
+++ b/src/components/molecules/CategoryModalLeft/index.tsx
@@ -53,8 +53,6 @@ const CategoryModalLeft = ({ optionData, handleSelectedInfo, handleOptionId, mse
 		domain: item.name,
 	}));
 
-	console.log('urlInfos:', urlInfos);
-
 	return (
 		<div className="h-[80rem] w-[68.8rem] rounded-l-[10px] bg-gray-bg-04 py-[2.8rem] pl-[4.4rem] pr-[4.3rem]">
 			<div className="mb-[3.3rem]">

--- a/src/components/molecules/CategoryModalLeft/index.tsx
+++ b/src/components/molecules/CategoryModalLeft/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Key, useState } from 'react';
 
 import CategoryCommonTitle from '@/components/atoms/CategoryCommonTitle';
 import CategoryMoribContentPage from '@/components/atoms/CategoryMoribContentPage';
@@ -11,16 +11,25 @@ import { CATEGORY_MODALTABS } from '@/constants/tabSelections';
 
 import AddBtn from '@/assets/svgs/add_btn.svg?react';
 
-import { CATEGORY_API } from '@/mocks/categoryData';
-
 interface UrlInfo {
 	url: string;
 	domain: string;
 	favicon: string;
 }
+
+interface msetsList {
+	createdAt: string;
+	updatedAt: string;
+	id: number;
+	name: string;
+	url: string;
+}
+
 interface ModalProps {
 	optionData: Category[];
 	handleSelectedInfo: (url: UrlInfo) => void;
+	handleOptionId: (id: number) => void;
+	msetsList: msetsList[];
 }
 
 interface Category {
@@ -30,7 +39,7 @@ interface Category {
 	endDate: string;
 }
 
-const CategoryModalLeft = ({ optionData, handleSelectedInfo }: ModalProps) => {
+const CategoryModalLeft = ({ optionData, handleSelectedInfo, handleOptionId, msetsList }: ModalProps) => {
 	const [isSelectedTab, setSelectedTab] = useState(CATEGORY_MODALTABS[0].id);
 
 	const handleTabChange = (tab: number) => {
@@ -38,11 +47,13 @@ const CategoryModalLeft = ({ optionData, handleSelectedInfo }: ModalProps) => {
 	};
 
 	const disabled = isSelectedTab === 2;
-	const urlInfos = CATEGORY_API[0].msetList.map((item) => ({
+	const urlInfos = msetsList.map((item) => ({
 		url: item.url,
-		favicon: `${item.url}/favicon.ico`,
+		favicon: `https://www.google.com/s2/favicons?domain=${item.url}`,
 		domain: item.name,
 	}));
+
+	console.log('urlInfos:', urlInfos);
 
 	return (
 		<div className="h-[80rem] w-[68.8rem] rounded-l-[10px] bg-gray-bg-04 py-[2.8rem] pl-[4.4rem] pr-[4.3rem]">
@@ -54,10 +65,10 @@ const CategoryModalLeft = ({ optionData, handleSelectedInfo }: ModalProps) => {
 			</div>
 
 			<div className="relative mt-[0px]">
-				<CategoryDropdown optionData={optionData} disabled={disabled} />
+				<CategoryDropdown optionData={optionData} disabled={disabled} handleOptionId={handleOptionId} />
 			</div>
 			<CategoryMoribContentSet variant="smallLeft" urlInfos={urlInfos}>
-				{urlInfos.map((urlInfo, url) => (
+				{urlInfos.map((urlInfo: UrlInfo, url: Key | null | undefined) => (
 					<tr
 						key={url}
 						className="group flex h-[4.6rem] w-[100%] gap-[1.2rem] border-b border-gray-bg-04 px-[0.8rem] hover:bg-gray-bg-04"

--- a/src/components/molecules/CategoryModalRight/index.tsx
+++ b/src/components/molecules/CategoryModalRight/index.tsx
@@ -9,7 +9,7 @@ import MinusBtn from '@/assets/svgs/minus_btn.svg?react';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 

--- a/src/components/molecules/CategoryModalRight/index.tsx
+++ b/src/components/molecules/CategoryModalRight/index.tsx
@@ -26,6 +26,7 @@ const CategoryModalRight = ({
 	handleDeleteUrlInfo,
 	handleCloseModal,
 }: ModalRightProps) => {
+	console.log('selectedInfo:', selectedInfo);
 	return (
 		<div className="flex h-[80rem] w-[61.2rem] flex-col items-end justify-between rounded-r-[1rem] bg-gray-bg-03 pb-[3rem] pl-[3rem] pr-[4.3rem] pt-[9.7rem]">
 			<div className="mb-[8px] flex w-full flex-row justify-start">

--- a/src/components/molecules/CategoryMoribContentSet/index.tsx
+++ b/src/components/molecules/CategoryMoribContentSet/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -5,8 +5,6 @@ import CategoryModalRight from '@/components/molecules/CategoryModalRight';
 
 import { useCategoryLists, useGetMsets } from '@/apis/modal/queries';
 
-import { URL_DATA } from '@/mocks/urlData';
-
 interface UrlInfo {
 	url: string;
 	domain: string;

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -3,6 +3,8 @@ import { RefObject, useState } from 'react';
 import CategoryModalLeft from '@/components/molecules/CategoryModalLeft';
 import CategoryModalRight from '@/components/molecules/CategoryModalRight';
 
+import { useCategoryLists } from '@/apis/modal/queries';
+
 import { CATEGORY_API } from '@/mocks/categoryData';
 import { URL_DATA } from '@/mocks/urlData';
 
@@ -20,12 +22,19 @@ type CategoryListModalProp = {
 const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModalProp) => {
 	const [selectedInfo, setSelectedInfo] = useState<UrlInfo[]>([]);
 
+	const { data: categoryData, isLoading, error } = useCategoryLists();
+	const categories = categoryData?.data || [];
+	console.log('cate:', categories);
+	if (isLoading) return <div>Loading...</div>;
+	if (error) return <div>Error loading todos</div>;
+
 	const handleSelectedInfo = (urlInfo: UrlInfo) => {
 		setSelectedInfo((prevUrlInfos) => [...prevUrlInfos, urlInfo]);
 	};
 
 	const handleUrlInputChange = (url: string) => {
 		const index = selectedInfo.length;
+
 		if (index < URL_DATA.length) {
 			const newUrlInfo: UrlInfo = {
 				url: url,
@@ -45,7 +54,7 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 		<dialog ref={dialogRef}>
 			<div className="flex">
 				<CategoryModalLeft
-					optionData={CATEGORY_API}
+					optionData={categories}
 					handleSelectedInfo={(urlInfo: UrlInfo) => handleSelectedInfo(urlInfo)}
 				/>
 				<CategoryModalRight

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -5,6 +5,8 @@ import CategoryModalRight from '@/components/molecules/CategoryModalRight';
 
 import { useCategoryLists, useGetMsets } from '@/apis/modal/queries';
 
+import { URL_DATA } from '@/mocks/urlData';
+
 interface UrlInfo {
 	url: string;
 	domain: string;
@@ -40,16 +42,16 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 			}
 			return [...prevItems, urlInfo]; // 존재하지 않으면 새로운 배열 반환
 		});
-		// setSelectedInfo((prevUrlInfos) => [...prevUrlInfos, urlInfo]);
 	};
 
 	const handleUrlInputChange = (url: string) => {
 		const index = selectedInfo.length;
 
-		if (index < msets.length) {
+		if (index < msetsList.length) {
 			const newUrlInfo: UrlInfo = {
 				url: url,
-				domain: msetsList[index].name,
+				//TODO: API로 가져온 tabName 추가 필요
+				domain: '',
 				favicon: `https://www.google.com/s2/favicons?domain=${url}`,
 			};
 

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -7,7 +7,7 @@ import { useCategoryLists, useGetMsets } from '@/apis/modal/queries';
 
 interface UrlInfo {
 	url: string;
-	domain: string;
+	domain?: string;
 	favicon: string;
 }
 
@@ -24,7 +24,6 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 	const [categoryId, setCategoryId] = useState<number>(0);
 
 	const { data: msets } = useGetMsets(categoryId);
-
 	const msetsList = msets?.data.msetList || [];
 	console.log('msetsList:', msetsList);
 	if (isLoading) return <div>Loading...</div>;
@@ -33,6 +32,7 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 	const handleOptionId = (id: number) => {
 		setCategoryId(id);
 	};
+
 	const handleSelectedInfo = (urlInfo: UrlInfo) => {
 		setSelectedInfo((prevItems) => {
 			if (prevItems.some((prevItem) => prevItem.url === urlInfo.url)) {

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -48,13 +48,13 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 		if (index < msetsList.length) {
 			const newUrlInfo: UrlInfo = {
 				url: url,
-				//TODO: API로 가져온 tabName 추가 필요
-				domain: '',
+
 				favicon: `https://www.google.com/s2/favicons?domain=${url}`,
 			};
 
 			setSelectedInfo((prevUrlInfos) => [...prevUrlInfos, newUrlInfo]);
 		}
+		console.log('input', selectedInfo);
 	};
 
 	const handleDeleteUrlInfo = (urlInfoToDelete: UrlInfo) => {

--- a/src/components/templates/AddCategoryListModal/index.tsx
+++ b/src/components/templates/AddCategoryListModal/index.tsx
@@ -25,7 +25,7 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 
 	const { data: msets } = useGetMsets(categoryId);
 	const msetsList = msets?.data.msetList || [];
-	console.log('msetsList:', msetsList);
+
 	if (isLoading) return <div>Loading...</div>;
 	if (error) return <div>Error loading</div>;
 
@@ -43,18 +43,12 @@ const AddCategoryListModal = ({ dialogRef, handleCloseModal }: CategoryListModal
 	};
 
 	const handleUrlInputChange = (url: string) => {
-		const index = selectedInfo.length;
+		const newUrlInfo: UrlInfo = {
+			url: url,
+			favicon: `https://www.google.com/s2/favicons?domain=${url}`,
+		};
 
-		if (index < msetsList.length) {
-			const newUrlInfo: UrlInfo = {
-				url: url,
-
-				favicon: `https://www.google.com/s2/favicons?domain=${url}`,
-			};
-
-			setSelectedInfo((prevUrlInfos) => [...prevUrlInfos, newUrlInfo]);
-		}
-		console.log('input', selectedInfo);
+		setSelectedInfo((prevUrlInfos) => [...prevUrlInfos, newUrlInfo]);
 	};
 
 	const handleDeleteUrlInfo = (urlInfoToDelete: UrlInfo) => {

--- a/src/pages/HomePage/AddCategoryModal/index.tsx
+++ b/src/pages/HomePage/AddCategoryModal/index.tsx
@@ -11,6 +11,8 @@ import CategoryMoribContentSet from '@/components/molecules/CategoryMoribContent
 import CategoryMoribSet from '@/components/molecules/CategoryMoribSet';
 import CategoryModal, { CategoryRef } from '@/components/templates/CategoryModal/index';
 
+import { useGetTabName } from '@/apis/modal/queries';
+
 import { URL_DATA } from '@/mocks/urlData.ts';
 
 interface UrlInfo {
@@ -22,6 +24,8 @@ interface UrlInfo {
 const AddCategoryModal = () => {
 	const [urlInfos, setUrlInfos] = useState<UrlInfo[]>([]);
 	const [name, setName] = useState('');
+
+	// const { data: tabNames, error, isLoading } = useGetTabName(requestUrl);
 
 	const handleNameChange = (newName: string) => {
 		setName(newName);

--- a/src/pages/HomePage/AddCategoryModal/index.tsx
+++ b/src/pages/HomePage/AddCategoryModal/index.tsx
@@ -4,14 +4,11 @@ import CategoryCommonBtn from '@/components/atoms/CategoryCommonBtn/index';
 import CategoryCommonTitle from '@/components/atoms/CategoryCommonTitle/index';
 import CategoryMoribContentPage from '@/components/atoms/CategoryMoribContentPage';
 import CategoryMoribContentUrl from '@/components/atoms/CategoryMoribContentUrl';
-import GetCategoryBtn from '@/components/atoms/GetCategoryBtn/index';
 import Calendar from '@/components/molecules/Calendar/index';
 import CategoryInputMoribName from '@/components/molecules/CategoryInputMoribName/index';
 import CategoryMoribContentSet from '@/components/molecules/CategoryMoribContentSet';
 import CategoryMoribSet from '@/components/molecules/CategoryMoribSet';
 import CategoryModal, { CategoryRef } from '@/components/templates/CategoryModal/index';
-
-import { useGetTabName } from '@/apis/modal/queries';
 
 import { URL_DATA } from '@/mocks/urlData.ts';
 

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -1,5 +1,3 @@
-import AddCategoryModal from '@/pages/HomePage/AddCategoryModal';
-
 import FriendInfoCarousel from '@/components/molecules/FriendInfoCarousel';
 import Timer from '@/components/molecules/Timer';
 import TimerSideBar from '@/components/molecules/TimerSideBar';
@@ -12,35 +10,34 @@ import useToggleSidebar from '@/hooks/useToggleSideBar';
 import HamburgerIcon from '@/assets/svgs/btn_hamburger.svg?react';
 
 const TimerPage = () => {
-	// const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
+	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
 
 	return (
-		<AddCategoryModal />
-		// <TimerPageTemplates>
-		// 	<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
-		// 		<div className="absolute left-0">
-		// 			<TimerSideBox />
-		// 		</div>
-		// 		<div className="ml-[56.6rem] mt-[-0.8rem]">
-		// 			<TimerTitle />
-		// 			<Timer />
-		// 			<FriendInfoCarousel />
-		// 		</div>
-		// 		<button
-		// 			onClick={toggleSidebar}
-		// 			className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
-		// 		>
-		// 			<HamburgerIcon />
-		// 		</button>
-		// 		{isSidebarOpen && (
-		// 			<div className="absolute inset-0 z-10 bg-dim">
-		// 				<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-		// 					<TimerSideBar toggleSidebar={toggleSidebar} />
-		// 				</div>
-		// 			</div>
-		// 		)}
-		// 	</div>
-		// </TimerPageTemplates>
+		<TimerPageTemplates>
+			<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
+				<div className="absolute left-0">
+					<TimerSideBox />
+				</div>
+				<div className="ml-[56.6rem] mt-[-0.8rem]">
+					<TimerTitle />
+					<Timer />
+					<FriendInfoCarousel />
+				</div>
+				<button
+					onClick={toggleSidebar}
+					className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
+				>
+					<HamburgerIcon />
+				</button>
+				{isSidebarOpen && (
+					<div className="absolute inset-0 z-10 bg-dim">
+						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
+							<TimerSideBar toggleSidebar={toggleSidebar} />
+						</div>
+					</div>
+				)}
+			</div>
+		</TimerPageTemplates>
 	);
 };
 export default TimerPage;

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -1,5 +1,3 @@
-import AddCategoryModal from '@/pages/HomePage/AddCategoryModal';
-
 import FriendInfoCarousel from '@/components/molecules/FriendInfoCarousel';
 import Timer from '@/components/molecules/Timer';
 import TimerSideBar from '@/components/molecules/TimerSideBar';
@@ -12,35 +10,34 @@ import useToggleSidebar from '@/hooks/useToggleSideBar';
 import HamburgerIcon from '@/assets/svgs/btn_hamburger.svg?react';
 
 const TimerPage = () => {
-	//const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
+	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
 
 	return (
-		<AddCategoryModal />
-		// <TimerPageTemplates>
-		// 	<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
-		// 		<div className="absolute left-0">
-		// 			<TimerSideBox />
-		// 		</div>
-		// 		<div className="ml-[56.6rem] mt-[-0.8rem]">
-		// 			<TimerTitle />
-		// 			<Timer />
-		// 			<FriendInfoCarousel />
-		// 		</div>
-		// 		<button
-		// 			onClick={toggleSidebar}
-		// 			className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
-		// 		>
-		// 			<HamburgerIcon />
-		// 		</button>
-		// 		{isSidebarOpen && (
-		// 			<div className="absolute inset-0 z-10 bg-dim">
-		// 				<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-		// 					<TimerSideBar toggleSidebar={toggleSidebar} />
-		// 				</div>
-		// 			</div>
-		// 		)}
-		// 	</div>
-		// </TimerPageTemplates>
+		<TimerPageTemplates>
+			<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
+				<div className="absolute left-0">
+					<TimerSideBox />
+				</div>
+				<div className="ml-[56.6rem] mt-[-0.8rem]">
+					<TimerTitle />
+					<Timer />
+					<FriendInfoCarousel />
+				</div>
+				<button
+					onClick={toggleSidebar}
+					className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
+				>
+					<HamburgerIcon />
+				</button>
+				{isSidebarOpen && (
+					<div className="absolute inset-0 z-10 bg-dim">
+						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
+							<TimerSideBar toggleSidebar={toggleSidebar} />
+						</div>
+					</div>
+				)}
+			</div>
+		</TimerPageTemplates>
 	);
 };
 export default TimerPage;

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -1,3 +1,5 @@
+import AddCategoryModal from '@/pages/HomePage/AddCategoryModal';
+
 import FriendInfoCarousel from '@/components/molecules/FriendInfoCarousel';
 import Timer from '@/components/molecules/Timer';
 import TimerSideBar from '@/components/molecules/TimerSideBar';
@@ -10,34 +12,35 @@ import useToggleSidebar from '@/hooks/useToggleSideBar';
 import HamburgerIcon from '@/assets/svgs/btn_hamburger.svg?react';
 
 const TimerPage = () => {
-	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
+	//const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
 
 	return (
-		<TimerPageTemplates>
-			<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
-				<div className="absolute left-0">
-					<TimerSideBox />
-				</div>
-				<div className="ml-[56.6rem] mt-[-0.8rem]">
-					<TimerTitle />
-					<Timer />
-					<FriendInfoCarousel />
-				</div>
-				<button
-					onClick={toggleSidebar}
-					className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
-				>
-					<HamburgerIcon />
-				</button>
-				{isSidebarOpen && (
-					<div className="absolute inset-0 z-10 bg-dim">
-						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-							<TimerSideBar toggleSidebar={toggleSidebar} />
-						</div>
-					</div>
-				)}
-			</div>
-		</TimerPageTemplates>
+		<AddCategoryModal />
+		// <TimerPageTemplates>
+		// 	<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
+		// 		<div className="absolute left-0">
+		// 			<TimerSideBox />
+		// 		</div>
+		// 		<div className="ml-[56.6rem] mt-[-0.8rem]">
+		// 			<TimerTitle />
+		// 			<Timer />
+		// 			<FriendInfoCarousel />
+		// 		</div>
+		// 		<button
+		// 			onClick={toggleSidebar}
+		// 			className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
+		// 		>
+		// 			<HamburgerIcon />
+		// 		</button>
+		// 		{isSidebarOpen && (
+		// 			<div className="absolute inset-0 z-10 bg-dim">
+		// 				<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
+		// 					<TimerSideBar toggleSidebar={toggleSidebar} />
+		// 				</div>
+		// 			</div>
+		// 		)}
+		// 	</div>
+		// </TimerPageTemplates>
 	);
 };
 export default TimerPage;

--- a/src/pages/TimerPage/index.tsx
+++ b/src/pages/TimerPage/index.tsx
@@ -1,3 +1,5 @@
+import AddCategoryModal from '@/pages/HomePage/AddCategoryModal';
+
 import FriendInfoCarousel from '@/components/molecules/FriendInfoCarousel';
 import Timer from '@/components/molecules/Timer';
 import TimerSideBar from '@/components/molecules/TimerSideBar';
@@ -10,34 +12,35 @@ import useToggleSidebar from '@/hooks/useToggleSideBar';
 import HamburgerIcon from '@/assets/svgs/btn_hamburger.svg?react';
 
 const TimerPage = () => {
-	const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
+	// const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
 
 	return (
-		<TimerPageTemplates>
-			<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
-				<div className="absolute left-0">
-					<TimerSideBox />
-				</div>
-				<div className="ml-[56.6rem] mt-[-0.8rem]">
-					<TimerTitle />
-					<Timer />
-					<FriendInfoCarousel />
-				</div>
-				<button
-					onClick={toggleSidebar}
-					className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
-				>
-					<HamburgerIcon />
-				</button>
-				{isSidebarOpen && (
-					<div className="absolute inset-0 z-10 bg-dim">
-						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-							<TimerSideBar toggleSidebar={toggleSidebar} />
-						</div>
-					</div>
-				)}
-			</div>
-		</TimerPageTemplates>
+		<AddCategoryModal />
+		// <TimerPageTemplates>
+		// 	<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/assets/images/img_timer_bg.png')]">
+		// 		<div className="absolute left-0">
+		// 			<TimerSideBox />
+		// 		</div>
+		// 		<div className="ml-[56.6rem] mt-[-0.8rem]">
+		// 			<TimerTitle />
+		// 			<Timer />
+		// 			<FriendInfoCarousel />
+		// 		</div>
+		// 		<button
+		// 			onClick={toggleSidebar}
+		// 			className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
+		// 		>
+		// 			<HamburgerIcon />
+		// 		</button>
+		// 		{isSidebarOpen && (
+		// 			<div className="absolute inset-0 z-10 bg-dim">
+		// 				<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
+		// 					<TimerSideBar toggleSidebar={toggleSidebar} />
+		// 				</div>
+		// 			</div>
+		// 		)}
+		// 	</div>
+		// </TimerPageTemplates>
 	);
 };
 export default TimerPage;


### PR DESCRIPTION

## 🔥 Related Issues

- close #95 

## ✅ 작업 내용

- [x] url로 탭이름 가져오기
- [x] 카테고리 조회
- [x] 다른 카테고리에서 모립세트 불러오기

## 📸 스크린샷
https://github.com/user-attachments/assets/d7ed3d91-47cd-4463-9287-65ab8bbc5da8

- 빌드 에러 확인
<img width="820" alt="스크린샷 2024-07-17 오후 3 12 11" src="https://github.com/user-attachments/assets/690869c2-5acb-46a4-b5e6-dac85875b165">
![Uploading 스크린샷 2024-07-17 오후 3.12.04.png…]()


## 📌 이슈 사항
input 창에 url 입력 후 추가하는 부분 수정 필요, 입력한 url이 selectedInfo에 추가되어야 하는데 https://www.naver.com을 제외한 모든 url이 추가가 안되는 이슈가 있음
-> 카테고리 드롭다운 API 연결 이후 발생한 이슈로 상아 작업한 이슈랑 머지한 후 자잘한 이슈 한번에 해결할 예정
