### PR TITLE
[ Feat ] 특정 태스크의 모립세트 불러오기 API 연결 + 익스텐션 연결

### DIFF
--- a/src/apis/timer/axios/index.ts
+++ b/src/apis/timer/axios/index.ts
@@ -3,12 +3,18 @@ import { nonAuthClient } from '@/apis/client';
 const TIMER_URL = {
 	GET_TODOLIST: `api/v1/timer/todo-card`,
 	POST_TIMERSTOP: (taskId: number) => `api/v1/timer/stop/${taskId}`,
+	GET_MORIBSET: (taskId: number) => `api/v1/mset/tasks/${taskId}`,
 };
 
 export const getTodoList = async (targetDate: string) => {
 	const { data } = await nonAuthClient.get(TIMER_URL.GET_TODOLIST, {
 		params: { targetDate: targetDate },
 	});
+	return data;
+};
+
+export const getMoribSet = async (taskId: number) => {
+	const { data } = await nonAuthClient.get(TIMER_URL.GET_MORIBSET(taskId));
 	return data;
 };
 

--- a/src/apis/timer/queries/index.ts
+++ b/src/apis/timer/queries/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { postTimerStop } from '@/apis/timer/axios';
+import { getMoribSet, postTimerStop } from '@/apis/timer/axios';
 
 import { getTodoList } from '../axios';
 
@@ -14,5 +14,12 @@ export const useGetTodoList = (targetDate: string) => {
 export const usePostTimerStop = () => {
 	return useMutation({
 		mutationFn: ({ id, elapsedTime }: { id: number; elapsedTime: number }) => postTimerStop(id, elapsedTime),
+	});
+};
+
+export const useGetMoribSet = (taskId: number) => {
+	return useQuery({
+		queryKey: ['set', taskId],
+		queryFn: () => getMoribSet(taskId),
 	});
 };

--- a/src/components/molecules/TimerSideBar/index.tsx
+++ b/src/components/molecules/TimerSideBar/index.tsx
@@ -82,6 +82,8 @@ const TimerSideBar = ({
 					},
 				},
 			);
+		} else {
+			navigate('/home');
 		}
 	};
 
@@ -91,7 +93,6 @@ const TimerSideBar = ({
 		>
 			<div className="flex h-[5.4rem] w-[36.6rem] items-center justify-between pl-[0.2rem] pt-[2rem]">
 				<p className="head-bold-24 text-white">오늘 할 일</p>
-
 				<button className="rounded-[1.5rem] hover:bg-gray-bg-04" onClick={handleClose}>
 					<BtnListIcon />
 				</button>

--- a/src/hooks/useUrlHandler.ts
+++ b/src/hooks/useUrlHandler.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+
+interface UseUrlHandlerProps {
+	isPlaying: boolean;
+	selectedTodo: number | null;
+	baseUrls: string[];
+	stopTimer: (params: { id: number; elapsedTime: number }, options: { onSuccess: () => void }) => void;
+	increasedTime: number;
+	setIsPlaying: (isPlaying: boolean) => void;
+	getBaseUrl: (url: string) => string;
+}
+
+const useUrlHandler = ({
+	isPlaying,
+	selectedTodo,
+	baseUrls,
+	stopTimer,
+	increasedTime,
+	setIsPlaying,
+	getBaseUrl,
+}: UseUrlHandlerProps) => {
+	useEffect(() => {
+		const handleMessage = (event: any) => {
+			if (event.detail.action === 'urlUpdated') {
+				const updatedUrl = event.detail.url.trim();
+				const updatedBaseUrl = getBaseUrl(updatedUrl);
+
+				setTimeout(() => {
+					if (isPlaying && selectedTodo !== null && !baseUrls.includes(updatedBaseUrl)) {
+						stopTimer(
+							{ id: selectedTodo, elapsedTime: increasedTime },
+							{
+								onSuccess: () => {
+									setIsPlaying(false);
+								},
+							},
+						);
+					}
+				}, 0);
+			}
+		};
+
+		document.addEventListener('FROM_EXTENSION', handleMessage);
+
+		return () => {
+			document.removeEventListener('FROM_EXTENSION', handleMessage);
+		};
+	}, [increasedTime, isPlaying, selectedTodo, stopTimer, baseUrls, getBaseUrl, setIsPlaying]);
+};
+
+export default useUrlHandler;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #126 

## ✅ 작업 내용

- [x]  특정 태스크의 모립세트 불러오기 api 연결
- [x]  익스텐션 연결하여 모립세트에 등록되지 않는 url 감지시 타이머 정지

모립세트 GET해오는 api 연결 후,
모립세트에 등록되지 않는 url 감지시 타이머 멈추는 기능 구현했습니다.

```typescript
import { useEffect } from 'react';

interface UseUrlHandlerProps {
	isPlaying: boolean;
	selectedTodo: number | null;
	baseUrls: string[];
	stopTimer: (params: { id: number; elapsedTime: number }, options: { onSuccess: () => void }) => void;
	increasedTime: number;
	setIsPlaying: (isPlaying: boolean) => void;
	getBaseUrl: (url: string) => string;
}

const useUrlHandler = ({
	isPlaying,
	selectedTodo,
	baseUrls,
	stopTimer,
	increasedTime,
	setIsPlaying,
	getBaseUrl,
}: UseUrlHandlerProps) => {
	useEffect(() => {
		const handleMessage = (event: any) => {
			if (event.detail.action === 'urlUpdated') {
				const updatedUrl = event.detail.url.trim();
				const updatedBaseUrl = getBaseUrl(updatedUrl);

				setTimeout(() => {
					if (isPlaying && selectedTodo !== null && !baseUrls.includes(updatedBaseUrl)) {
						stopTimer(
							{ id: selectedTodo, elapsedTime: increasedTime },
							{
								onSuccess: () => {
									setIsPlaying(false);
								},
							},
						);
					}
				}, 0);
			}
		};

		document.addEventListener('FROM_EXTENSION', handleMessage);

		return () => {
			document.removeEventListener('FROM_EXTENSION', handleMessage);
		};
	}, [increasedTime, isPlaying, selectedTodo, stopTimer, baseUrls, getBaseUrl, setIsPlaying]);
};

export default useUrlHandler;
```
모립세트 url과 사용자가 탭한 url 비교하여 정지 액션 api쏘는 로직 커스텀 훅으로 분리 하였습니다.

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/e3a879de-42e7-485f-ae11-594fe8b5115a

<img width="626" alt="스크린샷 2024-07-18 오후 8 56 45" src="https://github.com/user-attachments/assets/a2378ebb-1130-4dcd-8a1d-b4d7c9744a66">

제가 맡은 컴포넌트에는 build 문제 없는 것 확인 했습니다
## 📌 이슈 사항

## ✍ 궁금한 것