### PR TITLE
[ Feat ] 할일 추가 후 타이머 시작 

### DIFF
--- a/src/apis/home/axios/index.ts
+++ b/src/apis/home/axios/index.ts
@@ -7,6 +7,7 @@ const HOME_URL = {
 	POST_CREATE_CATEGORY: (categoryId: number) => `api/v1/tasks/${categoryId}`,
 	POST_CREATE_TODAY_TODOS: 'api/v1/timer/start',
 	DELETE_CATEGORY: (categoryId: number) => `api/v1/categories/${categoryId}`,
+	GET_TARGET_TIME: 'api/v1/timer',
 };
 
 export const getAllCategoryTask = async (startDate: string, endDate: string) => {
@@ -30,4 +31,9 @@ export const postCreateTodayTodosProps = async ({ todayDate, todayTodos }: PostC
 
 export const deleteCategory = async (categoryId: number) => {
 	await nonAuthClient.delete(HOME_URL.DELETE_CATEGORY(categoryId));
+};
+
+export const getTargetTime = async (todayDate: string) => {
+	const { data } = await nonAuthClient.get(HOME_URL.GET_TARGET_TIME, { params: { targetDate: todayDate } });
+	return data;
 };

--- a/src/apis/home/axios/index.ts
+++ b/src/apis/home/axios/index.ts
@@ -6,6 +6,7 @@ const HOME_URL = {
 	GET_ALL_CATEGORY_TASK: 'api/v1/resources',
 	POST_CREATE_CATEGORY: (categoryId: number) => `api/v1/tasks/${categoryId}`,
 	POST_CREATE_TODAY_TODOS: 'api/v1/timer/start',
+	DELETE_CATEGORY: (categoryId: number) => `api/v1/categories/${categoryId}`,
 };
 
 export const getAllCategoryTask = async (startDate: string, endDate: string) => {
@@ -25,4 +26,8 @@ export const postCreateTask = async ({ categoryId, taskData }: PostCreateTaskPro
 
 export const postCreateTodayTodosProps = async ({ todayDate, todayTodos }: PostCreateTodayTodosProps) => {
 	await nonAuthClient.post(HOME_URL.POST_CREATE_TODAY_TODOS, todayTodos, { params: { targetDate: todayDate } });
+};
+
+export const deleteCategory = async (categoryId: number) => {
+	await nonAuthClient.delete(HOME_URL.DELETE_CATEGORY(categoryId));
 };

--- a/src/apis/home/axios/index.ts
+++ b/src/apis/home/axios/index.ts
@@ -19,7 +19,5 @@ export const getAllCategoryTask = async (startDate: string, endDate: string) => 
 };
 
 export const postCreateTask = async ({ categoryId, taskData }: PostCreateTaskProps) => {
-	console.log(categoryId, taskData);
-
 	await nonAuthClient.post(HOME_URL.POST_CREATE_CATEGORY(categoryId), taskData);
 };

--- a/src/apis/home/axios/index.ts
+++ b/src/apis/home/axios/index.ts
@@ -1,10 +1,11 @@
 import { nonAuthClient } from '@/apis/client';
 
-import { PostCreateTaskProps } from '../types';
+import { PostCreateTaskProps, PostCreateTodayTodosProps } from '../types';
 
 const HOME_URL = {
 	GET_ALL_CATEGORY_TASK: 'api/v1/resources',
 	POST_CREATE_CATEGORY: (categoryId: number) => `api/v1/tasks/${categoryId}`,
+	POST_CREATE_TODAY_TODOS: 'api/v1/timer/start',
 };
 
 export const getAllCategoryTask = async (startDate: string, endDate: string) => {
@@ -20,4 +21,8 @@ export const getAllCategoryTask = async (startDate: string, endDate: string) => 
 
 export const postCreateTask = async ({ categoryId, taskData }: PostCreateTaskProps) => {
 	await nonAuthClient.post(HOME_URL.POST_CREATE_CATEGORY(categoryId), taskData);
+};
+
+export const postCreateTodayTodosProps = async ({ todayDate, todayTodos }: PostCreateTodayTodosProps) => {
+	await nonAuthClient.post(HOME_URL.POST_CREATE_TODAY_TODOS, todayTodos, { params: { targetDate: todayDate } });
 };

--- a/src/apis/home/queries/index.ts
+++ b/src/apis/home/queries/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { deleteCategory, getAllCategoryTask, postCreateTask, postCreateTodayTodosProps } from '../axios';
+import { deleteCategory, getAllCategoryTask, getTargetTime, postCreateTask, postCreateTodayTodosProps } from '../axios';
 
 export const useGetAllCategoryTask = (startDate: string, endDate: string) => {
 	return useQuery({
@@ -33,5 +33,12 @@ export const useDeleteCategory = () => {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['todo'] });
 		},
+	});
+};
+
+export const useGetTargetTime = (todayDate: string) => {
+	return useQuery({
+		queryKey: ['todo', todayDate],
+		queryFn: () => getTargetTime(todayDate),
 	});
 };

--- a/src/apis/home/queries/index.ts
+++ b/src/apis/home/queries/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getAllCategoryTask, postCreateTask, postCreateTodayTodosProps } from '../axios';
+import { deleteCategory, getAllCategoryTask, postCreateTask, postCreateTodayTodosProps } from '../axios';
 
 export const useGetAllCategoryTask = (startDate: string, endDate: string) => {
 	return useQuery({
@@ -23,5 +23,15 @@ export const usePostCreateTask = () => {
 export const usePostCreateTodayTodos = () => {
 	return useMutation({
 		mutationFn: postCreateTodayTodosProps,
+	});
+};
+
+export const useDeleteCategory = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: deleteCategory,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['todo'] });
+		},
 	});
 };

--- a/src/apis/home/queries/index.ts
+++ b/src/apis/home/queries/index.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getAllCategoryTask, postCreateTask } from '../axios';
+import { getAllCategoryTask, postCreateTask, postCreateTodayTodosProps } from '../axios';
 
 export const useGetAllCategoryTask = (startDate: string, endDate: string) => {
 	return useQuery({
@@ -17,5 +17,11 @@ export const usePostCreateTask = () => {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['todo'] });
 		},
+	});
+};
+
+export const usePostCreateTodayTodos = () => {
+	return useMutation({
+		mutationFn: postCreateTodayTodosProps,
 	});
 };

--- a/src/apis/home/types/index.ts
+++ b/src/apis/home/types/index.ts
@@ -8,3 +8,12 @@ export interface PostCreateTaskProps {
 	categoryId: number;
 	taskData: TaskDataTypes;
 }
+
+export interface TodayTodosIds {
+	taskIdList: number[];
+}
+
+export interface PostCreateTodayTodosProps {
+	todayDate: string;
+	todayTodos: TodayTodosIds;
+}

--- a/src/components/atoms/TodoBox/index.tsx
+++ b/src/components/atoms/TodoBox/index.tsx
@@ -52,7 +52,12 @@ const TodoBox = ({
 	const TimeIcon = targetTime ? <TimeFillIcon /> : <TimeLineIcon />;
 	const timeTextClass = targetTime ? 'text-mint-01' : 'text-gray-04';
 
-	const selectedStyle = isSelected && !addingComplete ? ' border-[0.2rem] border-mint-01' : '';
+	const selectedStyle =
+		isSelected && !addingComplete
+			? ' border-[0.2rem] border-mint-01 bg-gray-bg-01'
+			: addingComplete !== clickable
+				? ' bg-gray-bg-02'
+				: ' bg-gray-bg-01';
 
 	const duration = formattedendDate ? `${formattedstartDate}~${formattedendDate}` : formattedstartDate;
 
@@ -67,15 +72,19 @@ const TodoBox = ({
 		}
 	};
 
+	const disableBtnStyle = clickable ? 'pointer-events-none' : '';
+
 	return (
 		<div
-			className={`group relative mt-[1rem] h-[9.6rem] w-[36.6rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle} ${clickStyle} ${disableClick}`}
+			className={`group relative mt-[1rem] h-[9.6rem] w-[36.6rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle} ${clickStyle} ${disableClick} `}
 			onClick={handleClickTodo}
 		>
 			<div className="flex flex-col justify-center">
 				<div className="flex items-center justify-between">
 					<div className="flex items-center gap-[0.6rem]">
-						<SVGBtn onClick={onToggleComplete}>{CheckBoxIcon}</SVGBtn>
+						<SVGBtn onClick={onToggleComplete} className={disableBtnStyle}>
+							{CheckBoxIcon}
+						</SVGBtn>
 						<h3 className={`body-semibold-16 + mt-[0.42rem] text-white ${nameStyle}`}>{name}</h3>
 					</div>
 					<SVGBtn>

--- a/src/components/atoms/TodoBox/index.tsx
+++ b/src/components/atoms/TodoBox/index.tsx
@@ -1,12 +1,13 @@
 import { formatSeconds } from '@/utils/time';
 
+import { Task } from '@/types/home';
+
 import ButtonCalendarIcon from '@/assets/svgs/btn_cal.svg?react';
 import CheckBoxBlankIcon from '@/assets/svgs/check_box_blank.svg?react';
 import CheckBoxFillIcon from '@/assets/svgs/check_box_fill.svg?react';
 import TimeFillIcon from '@/assets/svgs/mingcute_time-fill.svg?react';
 import TimeLineIcon from '@/assets/svgs/mingcute_time-line.svg?react';
-
-/*import NumberIcon from '@/assets/svgs/selected_number_icon.svg?react';*/
+import NumberIcon from '@/assets/svgs/selected_number_icon.svg?react';
 import MeatBall from '@/assets/svgs/todo_meatball_default.svg?react';
 
 import SVGBtn from '../SVGBtn';
@@ -18,22 +19,28 @@ interface TodoBoxProps {
 	endDate: string | null;
 	targetTime: number;
 	isComplete?: boolean;
-	isSelected: boolean;
+	isSelected?: boolean;
 	selectedNumber?: number;
 	onClick?: () => void;
 	onToggleComplete?: () => void;
+	updateTodayTodos?: (todo: Omit<Task, 'isComplete'>) => void;
+	clickable?: boolean;
+	addingComplete?: boolean;
 }
-
 const TodoBox = ({
+	id,
 	name,
 	startDate,
 	endDate,
 	targetTime,
 	isComplete,
 	isSelected,
-	/*selectedNumber = 1,*/
+	selectedNumber,
 	onClick,
 	onToggleComplete,
+	updateTodayTodos,
+	clickable,
+	addingComplete,
 }: TodoBoxProps) => {
 	const formattedTime = formatSeconds(targetTime);
 	const formattedstartDate = startDate.replace(/-/g, '.');
@@ -45,14 +52,25 @@ const TodoBox = ({
 	const TimeIcon = targetTime ? <TimeFillIcon /> : <TimeLineIcon />;
 	const timeTextClass = targetTime ? 'text-mint-01' : 'text-gray-04';
 
-	const selectedStyle = isSelected ? ' border-[0.2rem] border-mint-01' : '';
+	const selectedStyle = isSelected && !addingComplete ? ' border-[0.2rem] border-mint-01' : '';
 
 	const duration = formattedendDate ? `${formattedstartDate}~${formattedendDate}` : formattedstartDate;
 
+	const clickStyle = clickable && !addingComplete ? 'cursor-pointer' : 'cursor-default';
+
+	const disableClick = addingComplete ? 'pointer-events-none' : '';
+
+	const handleClickTodo = () => {
+		if (clickable && updateTodayTodos) updateTodayTodos({ id, name, startDate, endDate, targetTime });
+		else if (onClick) {
+			onClick();
+		}
+	};
+
 	return (
 		<div
-			className={`group relative mt-[1rem] h-[9.6rem] w-[36.6rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle}`}
-			onClick={onClick}
+			className={`group relative mt-[1rem] h-[9.6rem] w-[36.6rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle} ${clickStyle} ${disableClick}`}
+			onClick={handleClickTodo}
 		>
 			<div className="flex flex-col justify-center">
 				<div className="flex items-center justify-between">
@@ -75,14 +93,14 @@ const TodoBox = ({
 						<p className={`detail-reg-12 mt-[0.3rem] ${timeTextClass}`}>{formattedTime}</p>
 					</div>
 				</div>
-				{/* {isSelected && (
+				{isSelected && selectedNumber && (
 					<div className="absolute bottom-[1.1rem] right-[1.7rem]">
 						<div className="relative h-[2.2rem] w-[2.2rem]">
 							<NumberIcon className="absolute inset-0" />
 							<p className="body-reg-16 absolute inset-0 mt-[0.15rem] text-center">{selectedNumber}</p>
 						</div>
 					</div>
-				)} */}
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/atoms/TodoBox/index.tsx
+++ b/src/components/atoms/TodoBox/index.tsx
@@ -17,7 +17,7 @@ interface TodoBoxProps {
 	startDate: string;
 	endDate: string | null;
 	targetTime: number;
-	isComplete: boolean;
+	isComplete?: boolean;
 	isSelected: boolean;
 	selectedNumber?: number;
 	onClick?: () => void;

--- a/src/components/molecules/CategoryBox/index.tsx
+++ b/src/components/molecules/CategoryBox/index.tsx
@@ -29,6 +29,7 @@ interface CategoryBoxProps {
 	addingTodayTodoStatus: boolean;
 	getSelectedNumber: (id: number) => number;
 	addingComplete: boolean;
+	onDeleteCategory: (categoryId: number) => void;
 }
 
 const format = (date: Date | null) => {
@@ -48,6 +49,7 @@ const CategoryBox = ({
 	addingTodayTodoStatus,
 	getSelectedNumber,
 	addingComplete,
+	onDeleteCategory,
 }: CategoryBoxProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
 
@@ -65,6 +67,20 @@ const CategoryBox = ({
 
 	const todoRef = useRef<HTMLDivElement>(null);
 
+	useClickOutside(todoRef, cancelAddingTodo, isAdding && editable);
+
+	const {
+		isPeriodOn,
+		selectedStartDate,
+		selectedEndDate,
+		isCalendarOpened,
+		defaultDate,
+		handlePeriodToggle,
+		handleStartDateInput,
+		handleEndDateInput,
+		handlePeriodEnd,
+	} = useCalendar();
+
 	const handleCreatePost = () => {
 		const dataToPost = {
 			categoryId: id,
@@ -78,20 +94,10 @@ const CategoryBox = ({
 
 		setName('');
 		setIsAdding(false);
+		handleStartDateInput(null);
+		handleEndDateInput(null);
+		handlePeriodEnd();
 	};
-
-	useClickOutside(todoRef, cancelAddingTodo, isAdding && editable);
-
-	const {
-		isPeriodOn,
-		selectedStartDate,
-		selectedEndDate,
-		isCalendarOpened,
-		defaultDate,
-		handlePeriodToggle,
-		handleStartDateInput,
-		handleEndDateInput,
-	} = useCalendar();
 
 	const { mutate: toggleTodoStatus } = usePatchTaskStatus();
 
@@ -107,7 +113,7 @@ const CategoryBox = ({
 					<SVGBtn onClick={startAddingTodo} className="rounded-full hover:bg-gray-bg-04 active:bg-gray-bg-05">
 						<ButtonAddIcon />
 					</SVGBtn>
-					<SVGBtn>
+					<SVGBtn onClick={() => onDeleteCategory(id)}>
 						<MeatBallDefault className="rounded-full hover:bg-gray-bg-04 active:bg-gray-bg-05" />
 					</SVGBtn>
 				</div>

--- a/src/components/molecules/CategoryBox/index.tsx
+++ b/src/components/molecules/CategoryBox/index.tsx
@@ -25,6 +25,10 @@ interface CategoryBoxProps {
 	title: string;
 	completedTodos: Task[];
 	ongoingTodos: Task[];
+	updateTodayTodos: (todo: Omit<Task, 'isComplete'>) => void;
+	addingTodayTodoStatus: boolean;
+	getSelectedNumber: (id: number) => number;
+	addingComplete: boolean;
 }
 
 const format = (date: Date | null) => {
@@ -35,7 +39,16 @@ const format = (date: Date | null) => {
 	return `${year}-${month}-${day}`;
 };
 
-const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: CategoryBoxProps) => {
+const CategoryBox = ({
+	id,
+	title,
+	ongoingTodos = [],
+	completedTodos = [],
+	updateTodayTodos,
+	addingTodayTodoStatus,
+	getSelectedNumber,
+	addingComplete,
+}: CategoryBoxProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
 
 	const {
@@ -134,17 +147,34 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 								</>
 							)}
 
-							{ongoingTodos.map(({ id, name, startDate, endDate, targetTime }) => (
-								<TodoBox
-									id={id}
-									key={id}
-									name={name}
-									startDate={startDate}
-									endDate={endDate}
-									targetTime={targetTime}
-									onToggleComplete={() => toggleTodoStatus(id)}
-								/>
-							))}
+							{ongoingTodos.map(({ id, name, startDate, endDate, targetTime }) => {
+								const todo = {
+									id: id,
+									name: name,
+									startDate: startDate,
+									endDate: endDate,
+									targetTime: targetTime,
+								};
+
+								const selectedNumber = getSelectedNumber(id);
+
+								return (
+									<TodoBox
+										id={id}
+										key={id}
+										name={name}
+										startDate={startDate}
+										endDate={endDate}
+										targetTime={targetTime}
+										isSelected={!!selectedNumber}
+										selectedNumber={selectedNumber}
+										onToggleComplete={() => toggleTodoStatus(id)}
+										updateTodayTodos={() => updateTodayTodos(todo)}
+										clickable={addingTodayTodoStatus}
+										addingComplete={addingComplete}
+									/>
+								);
+							})}
 						</TodoToggleBtn>
 
 						{completedTodos.length !== 0 && (
@@ -159,6 +189,7 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 										endDate={endDate}
 										targetTime={targetTime}
 										onToggleComplete={() => toggleTodoStatus(id)}
+										clickable={false}
 									/>
 								))}
 							</TodoToggleBtn>

--- a/src/components/molecules/CategoryBox/index.tsx
+++ b/src/components/molecules/CategoryBox/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import SVGBtn from '@/components/atoms/SVGBtn';
 import TodoBox from '@/components/atoms/TodoBox';
@@ -7,6 +7,7 @@ import TodoToggleBtn from '@/components/atoms/TodoToggleBtn';
 
 import { useCalendar } from '@/hooks/useCalendar';
 import useClickOutside from '@/hooks/useClickOutside';
+import { useCreateTodo } from '@/hooks/useCreateTodo';
 
 import { usePostCreateTask } from '@/apis/home/queries';
 
@@ -34,30 +35,21 @@ const format = (date: Date | null) => {
 };
 
 const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: CategoryBoxProps) => {
-	const [name, setName] = useState('');
-	const [isAdding, setIsAdding] = useState(false);
-	const [editable, setEditable] = useState(false);
 	const { mutate, isError, error } = usePostCreateTask();
 
-	const handleEditComplete = () => {
-		setEditable(false);
-	};
-
-	const handleInputChange = (name: string) => {
-		setName(name);
-	};
+	const {
+		name,
+		isAdding,
+		editable,
+		handleEditComplete,
+		handleInputChange,
+		startAddingTodo,
+		cancelAddingTodo,
+		setName,
+		setIsAdding,
+	} = useCreateTodo();
 
 	const todoRef = useRef<HTMLDivElement>(null);
-
-	const startAddingTodo = () => {
-		setIsAdding(true);
-		setEditable(true);
-	};
-
-	const cancelAddingTodo = () => {
-		setName('');
-		setIsAdding(false);
-	};
 
 	const handleCreatePost = () => {
 		const dataToPost = {
@@ -86,6 +78,10 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 		handleStartDateInput,
 		handleEndDateInput,
 	} = useCalendar();
+
+	if (isError) {
+		console.error(error);
+	}
 
 	return (
 		<div className="flex h-[73.2rem] w-[40.2rem] flex-shrink-0 flex-col rounded-[16px] bg-gray-bg-03 px-[1.8rem] pt-[1.8rem]">
@@ -136,7 +132,7 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 							)}
 
 							{ongoingTodos.map(({ id, name, startDate, endDate, targetTime }) => (
-								<TodoBox key={id} name={name} startDate={startDate} endDate={endDate} targetTime={targetTime} />
+								<TodoBox id={id} key={id} name={name} startDate={startDate} endDate={endDate} targetTime={targetTime} />
 							))}
 						</TodoToggleBtn>
 
@@ -144,6 +140,7 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 							<TodoToggleBtn isToggled={false}>
 								{completedTodos.map(({ id, name, startDate, endDate, targetTime }) => (
 									<TodoBox
+										id={id}
 										key={id}
 										isComplete
 										name={name}

--- a/src/components/molecules/CategoryBox/index.tsx
+++ b/src/components/molecules/CategoryBox/index.tsx
@@ -9,6 +9,7 @@ import { useCalendar } from '@/hooks/useCalendar';
 import useClickOutside from '@/hooks/useClickOutside';
 import { useCreateTodo } from '@/hooks/useCreateTodo';
 
+import { usePatchTaskStatus } from '@/apis/common/queries';
 import { usePostCreateTask } from '@/apis/home/queries';
 
 import { Task } from '@/types/home';
@@ -79,6 +80,8 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 		handleEndDateInput,
 	} = useCalendar();
 
+	const { mutate: toggleTodoStatus } = usePatchTaskStatus();
+
 	if (isError) {
 		console.error(error);
 	}
@@ -132,7 +135,15 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 							)}
 
 							{ongoingTodos.map(({ id, name, startDate, endDate, targetTime }) => (
-								<TodoBox id={id} key={id} name={name} startDate={startDate} endDate={endDate} targetTime={targetTime} />
+								<TodoBox
+									id={id}
+									key={id}
+									name={name}
+									startDate={startDate}
+									endDate={endDate}
+									targetTime={targetTime}
+									onToggleComplete={() => toggleTodoStatus(id)}
+								/>
 							))}
 						</TodoToggleBtn>
 
@@ -147,6 +158,7 @@ const CategoryBox = ({ id, title, ongoingTodos = [], completedTodos = [] }: Cate
 										startDate={startDate}
 										endDate={endDate}
 										targetTime={targetTime}
+										onToggleComplete={() => toggleTodoStatus(id)}
 									/>
 								))}
 							</TodoToggleBtn>

--- a/src/components/molecules/TodayTodoBox/TodayTodoBoxDefaultStatus.tsx
+++ b/src/components/molecules/TodayTodoBox/TodayTodoBoxDefaultStatus.tsx
@@ -3,33 +3,59 @@ import HomeSmallBtn from '@/components/atoms/HomeSmallBtn';
 import TodoBox from '@/components/atoms/TodoBox';
 
 import { HomeLargeBtnVariant } from '@/types/global';
+import { Task } from '@/types/home';
 
 import { LARGE_BTN_TEXT, SMALL_BTN_TEXT } from '@/constants/btnText';
 
 interface TodayTodoAddStatusProps {
-	selectedTodayTodos: TodoBoxProps[];
+	selectedTodayTodos: Omit<Task, 'isComplete'>[];
 	onDisableAddStatus: () => void;
+	deleteTodayTodos: (todo: Omit<Task, 'isComplete'>) => void;
+	getSelectedNumber: (id: number) => number;
+	enableComplete: () => void;
+	cancelComplte: () => void;
+	addingComplete: boolean;
+	onCreateTodayTodos: () => void;
 }
 
-interface TodoBoxProps {
-	title: string;
-	date: string;
-	accumulatedTime: number;
-}
-
-const TodayTodoBoxAddStatus = ({ selectedTodayTodos, onDisableAddStatus }: TodayTodoAddStatusProps) => {
+const TodayTodoBoxAddStatus = ({
+	selectedTodayTodos,
+	onDisableAddStatus,
+	deleteTodayTodos,
+	getSelectedNumber,
+	enableComplete,
+	cancelComplte,
+	addingComplete,
+	onCreateTodayTodos,
+}: TodayTodoAddStatusProps) => {
 	//Todo: 선택된 Todo들을 취소하고 다시 추가하는 로직 추가
 	const hasTodayTodos = !(selectedTodayTodos.length === 0);
+	const clickable = addingComplete ? '' : 'pointer-events-none cursor-default ';
 
 	return (
 		<div className="flex flex-grow flex-col justify-between">
 			{hasTodayTodos ? (
 				<ul className="mt-[0.7rem] max-h-[57.5rem] overflow-auto">
-					{selectedTodayTodos.map(({ accumulatedTime, date, title }, index) => (
-						<li key={index}>
-							<TodoBox targetTime={accumulatedTime} startDate={'2024-07-07'} endDate={'2024-07-21'} name={title} />
-						</li>
-					))}
+					{selectedTodayTodos.map(({ id, targetTime, startDate, endDate, name }) => {
+						const selectedNumber = getSelectedNumber(id);
+
+						return (
+							<li key={id}>
+								<TodoBox
+									id={id}
+									targetTime={targetTime}
+									startDate={startDate}
+									endDate={endDate}
+									name={name}
+									clickable={true}
+									isSelected={!!selectedNumber}
+									selectedNumber={selectedNumber}
+									updateTodayTodos={deleteTodayTodos}
+									addingComplete={addingComplete}
+								/>
+							</li>
+						);
+					})}
 				</ul>
 			) : (
 				<p className="head-bold-24 mx-auto mt-[22.2rem] text-center text-gray-05">
@@ -40,10 +66,20 @@ const TodayTodoBoxAddStatus = ({ selectedTodayTodos, onDisableAddStatus }: Today
 			)}
 
 			<div className="flex justify-between">
-				<HomeSmallBtn onClick={onDisableAddStatus}>{SMALL_BTN_TEXT.CANCEL}</HomeSmallBtn>
-				<HomeLargeBtn variant={HomeLargeBtnVariant.LARGE} disabled={!hasTodayTodos}>
-					{LARGE_BTN_TEXT.START_TIMER}
-				</HomeLargeBtn>
+				{selectedTodayTodos.length !== 0 ? (
+					addingComplete ? (
+						<HomeSmallBtn onClick={cancelComplte}>{SMALL_BTN_TEXT.MODIFICATION}</HomeSmallBtn>
+					) : (
+						<HomeSmallBtn onClick={enableComplete}>{SMALL_BTN_TEXT.COMPLETION}</HomeSmallBtn>
+					)
+				) : (
+					<HomeSmallBtn onClick={onDisableAddStatus}>{SMALL_BTN_TEXT.CANCEL}</HomeSmallBtn>
+				)}
+				<div className={clickable}>
+					<HomeLargeBtn variant={HomeLargeBtnVariant.LARGE} disabled={!hasTodayTodos} onClick={onCreateTodayTodos}>
+						{LARGE_BTN_TEXT.START_TIMER}
+					</HomeLargeBtn>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/molecules/TodayTodoBox/index.tsx
+++ b/src/components/molecules/TodayTodoBox/index.tsx
@@ -9,21 +9,21 @@ import TodayTodoBoxAddStatus from './TodayTodoBoxDefaultStatus';
 
 interface TodayTodoBoxProps {
 	time: number;
+	addingTodayTodoStatus: boolean;
 	selectedTodayTodos: TodoDataTypes[] | [];
 	hasTodos: boolean;
+	enableAddingTodayTodo: () => void;
+	disableAddingTodayTodo: () => void;
 }
 
-const TodayTodoBox = ({ time = 0, selectedTodayTodos = [], hasTodos = false }: TodayTodoBoxProps) => {
-	const [addStatus, setAddStatus] = useState(false);
-
-	const enableAddStatus = () => {
-		setAddStatus(true);
-	};
-
-	const disableAddStatus = () => {
-		setAddStatus(false);
-	};
-
+const TodayTodoBox = ({
+	addingTodayTodoStatus,
+	time = 0,
+	selectedTodayTodos = [],
+	hasTodos = false,
+	enableAddingTodayTodo,
+	disableAddingTodayTodo,
+}: TodayTodoBoxProps) => {
 	const { hours, minutes, seconds } = convertTime(time);
 
 	return (
@@ -33,10 +33,10 @@ const TodayTodoBox = ({ time = 0, selectedTodayTodos = [], hasTodos = false }: T
 				<p className="title-bold-32">{`${hours}시간 ${minutes}분 ${seconds}초`}</p>
 			</div>
 			<h3 className="head-bold-24 mt-[3.2rem] text-white">오늘 할 일</h3>
-			{addStatus ? (
-				<TodayTodoBoxAddStatus selectedTodayTodos={selectedTodayTodos} onDisableAddStatus={disableAddStatus} />
+			{addingTodayTodoStatus ? (
+				<TodayTodoBoxAddStatus selectedTodayTodos={selectedTodayTodos} onDisableAddStatus={disableAddingTodayTodo} />
 			) : (
-				<TodayTodoBoxDefaultStatus hasTodos={hasTodos} onEnableAddStatus={enableAddStatus} />
+				<TodayTodoBoxDefaultStatus hasTodos={hasTodos} onEnableAddStatus={enableAddingTodayTodo} />
 			)}
 		</div>
 	);

--- a/src/components/molecules/TodayTodoBox/index.tsx
+++ b/src/components/molecules/TodayTodoBox/index.tsx
@@ -1,6 +1,6 @@
 import { convertTime } from '@/utils/time';
 
-import { TodoDataTypes } from '@/types/userData';
+import { Task } from '@/types/home';
 
 import TodayTodoBoxDefaultStatus from './TodayTodoBoxAddStatus';
 import TodayTodoBoxAddStatus from './TodayTodoBoxDefaultStatus';
@@ -8,19 +8,31 @@ import TodayTodoBoxAddStatus from './TodayTodoBoxDefaultStatus';
 interface TodayTodoBoxProps {
 	time: number;
 	addingTodayTodoStatus: boolean;
-	selectedTodayTodos: TodoDataTypes[] | [];
+	selectedTodayTodos: Omit<Task, 'isComplete'>[];
 	hasTodos: boolean;
 	enableAddingTodayTodo: () => void;
 	disableAddingTodayTodo: () => void;
+	deleteTodayTodos: (todo: Omit<Task, 'isComplete'>) => void;
+	getSelectedNumber: (id: number) => number;
+	enableComplete: () => void;
+	cancelComplte: () => void;
+	addingComplete: boolean;
+	onCreateTodayTodos: () => void;
 }
 
 const TodayTodoBox = ({
 	addingTodayTodoStatus,
 	time = 0,
-	selectedTodayTodos = [],
+	selectedTodayTodos,
 	hasTodos = false,
 	enableAddingTodayTodo,
 	disableAddingTodayTodo,
+	deleteTodayTodos,
+	getSelectedNumber,
+	enableComplete,
+	cancelComplte,
+	addingComplete,
+	onCreateTodayTodos,
 }: TodayTodoBoxProps) => {
 	const { hours, minutes, seconds } = convertTime(time);
 
@@ -32,7 +44,16 @@ const TodayTodoBox = ({
 			</div>
 			<h3 className="head-bold-24 mt-[3.2rem] text-white">오늘 할 일</h3>
 			{addingTodayTodoStatus ? (
-				<TodayTodoBoxAddStatus selectedTodayTodos={selectedTodayTodos} onDisableAddStatus={disableAddingTodayTodo} />
+				<TodayTodoBoxAddStatus
+					selectedTodayTodos={selectedTodayTodos}
+					onDisableAddStatus={disableAddingTodayTodo}
+					deleteTodayTodos={deleteTodayTodos}
+					getSelectedNumber={getSelectedNumber}
+					enableComplete={enableComplete}
+					cancelComplte={cancelComplte}
+					addingComplete={addingComplete}
+					onCreateTodayTodos={onCreateTodayTodos}
+				/>
 			) : (
 				<TodayTodoBoxDefaultStatus hasTodos={hasTodos} onEnableAddStatus={enableAddingTodayTodo} />
 			)}

--- a/src/components/molecules/TodayTodoBox/index.tsx
+++ b/src/components/molecules/TodayTodoBox/index.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { convertTime } from '@/utils/time';
 
 import { TodoDataTypes } from '@/types/userData';

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -15,6 +15,10 @@ export const useCalendar = () => {
 		setIsPeriodOn((prev) => !prev);
 	};
 
+	const handlePeriodEnd = () => {
+		setIsPeriodOn(false);
+	};
+
 	const handleOpenCalendar = () => {
 		setIsCalendarOpened(true);
 	};
@@ -37,5 +41,6 @@ export const useCalendar = () => {
 		handleOpenCalendar,
 		handleStartDateInput,
 		handleEndDateInput,
+		handlePeriodEnd,
 	};
 };

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -4,7 +4,7 @@ export const useCalendar = () => {
 	const defaultDate = new Date();
 
 	const [isPeriodOn, setIsPeriodOn] = useState(false);
-	const [selectedStartDate, setSelectedStartDate] = useState<Date | null>(null);
+	const [selectedStartDate, setSelectedStartDate] = useState<Date | null>(defaultDate);
 	const [selectedEndDate, setSelectedEndDate] = useState<Date | null>(null);
 	const [isCalendarOpened, setIsCalendarOpened] = useState(true);
 

--- a/src/hooks/useCreateTodo.ts
+++ b/src/hooks/useCreateTodo.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+export const useCreateTodo = () => {
+	const [name, setName] = useState('');
+	const [isAdding, setIsAdding] = useState(false);
+	const [editable, setEditable] = useState(false);
+
+	const handleEditComplete = () => {
+		setEditable(false);
+	};
+
+	const handleInputChange = (name: string) => {
+		setName(name);
+	};
+
+	const startAddingTodo = () => {
+		setIsAdding(true);
+		setEditable(true);
+	};
+
+	const cancelAddingTodo = () => {
+		setName('');
+		setIsAdding(false);
+	};
+
+	return {
+		name,
+		isAdding,
+		editable,
+		handleEditComplete,
+		handleInputChange,
+		startAddingTodo,
+		cancelAddingTodo,
+		setName,
+		setIsAdding,
+	};
+};

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -19,6 +19,8 @@ import { useGetAllCategoryTask } from '@/apis/home/queries';
 import { getThisWeekRange } from '@/utils/date';
 import { getDailyCategoryTask, isTaskExist, splitTasksByCompletion } from '@/utils/homePage';
 
+import { Task } from '@/types/home';
+
 import BellIcon from '@/assets/svgs/bell.svg?react';
 import FriendSettingIcon from '@/assets/svgs/friend_setting.svg?react';
 import LargePlusIcon from '@/assets/svgs/large_plus.svg?react';
@@ -38,6 +40,12 @@ const HomePage = () => {
 
 	const [addingTodayTodoStatus, setAddingTodayTodoStatus] = useState(false);
 	const addTodayTodoOverlayStyle = addingTodayTodoStatus ? 'opacity-30 pointer-events-none' : '';
+
+	const [selectedTodayTodos, setSelectedTodayTodos] = useState<Task[]>([]);
+
+	const handleAddSelectedTodayTodos = (todo: Task) => {
+		setSelectedTodayTodos((prev) => [...prev, todo]);
+	};
 
 	const disableAddingTodayTodo = () => {
 		setAddingTodayTodoStatus(false);

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -15,7 +15,8 @@ import HomeSideBar from '@/components/molecules/HomeSideBar';
 import TodayTodoBox from '@/components/molecules/TodayTodoBox';
 import HomePageWrapper from '@/components/templates/HomePageWrapper';
 
-import { useGetAllCategoryTask, usePostCreateTodayTodos } from '@/apis/home/queries';
+import { deleteCategory } from '@/apis/home/axios';
+import { useDeleteCategory, useGetAllCategoryTask, usePostCreateTodayTodos } from '@/apis/home/queries';
 
 import { getThisWeekRange } from '@/utils/date';
 import { getDailyCategoryTask, isTaskExist, splitTasksByCompletion } from '@/utils/homePage';
@@ -31,6 +32,7 @@ import LargePlusIcon from '@/assets/svgs/large_plus.svg?react';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+//Todo: 에러 핸들링 및 로직 분리 리팩토링 필요
 const HomePage = () => {
 	const todayDate = dayjs().tz('Asia/Seoul');
 	const formattedTodayDate = todayDate.format('YYYY-MM-DD');
@@ -49,6 +51,7 @@ const HomePage = () => {
 	const [todayTodos, setTodayTodos] = useState<Omit<Task, 'isComplete'>[]>([]);
 
 	const { mutate: createTodayTodos } = usePostCreateTodayTodos();
+	const { mutate: deleteCategory } = useDeleteCategory();
 
 	const navigate = useNavigate();
 
@@ -105,6 +108,10 @@ const HomePage = () => {
 		});
 	};
 
+	const handleDeleteCategory = (userId: number) => {
+		deleteCategory(userId);
+	};
+
 	if (isError) {
 		console.error(error);
 	}
@@ -155,6 +162,7 @@ const HomePage = () => {
 												addingTodayTodoStatus={addingTodayTodoStatus}
 												getSelectedNumber={getSelectedNumber}
 												addingComplete={addingComplete}
+												onDeleteCategory={handleDeleteCategory}
 											/>
 										);
 									})}

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -15,8 +15,12 @@ import HomeSideBar from '@/components/molecules/HomeSideBar';
 import TodayTodoBox from '@/components/molecules/TodayTodoBox';
 import HomePageWrapper from '@/components/templates/HomePageWrapper';
 
-import { deleteCategory } from '@/apis/home/axios';
-import { useDeleteCategory, useGetAllCategoryTask, usePostCreateTodayTodos } from '@/apis/home/queries';
+import {
+	useDeleteCategory,
+	useGetAllCategoryTask,
+	useGetTargetTime,
+	usePostCreateTodayTodos,
+} from '@/apis/home/queries';
 
 import { getThisWeekRange } from '@/utils/date';
 import { getDailyCategoryTask, isTaskExist, splitTasksByCompletion } from '@/utils/homePage';
@@ -60,6 +64,14 @@ const HomePage = () => {
 		if (canAddTask) setTodayTodos((prev) => [...prev, todo]);
 		else setTodayTodos((prev) => prev.filter((prevTodo) => prevTodo.id !== todo.id));
 	};
+
+	const {
+		data: targetTimeData,
+		error: targetTimeError,
+		isError: isTargetTimeError,
+	} = useGetTargetTime(formattedTodayDate);
+
+	const { targetTime } = targetTimeData?.data || 0;
 
 	const deleteTodayTodos = (todo: Omit<Task, 'isComplete'>) => {
 		setTodayTodos((prev) => prev.filter((prevTodo) => prevTodo.id !== todo.id));
@@ -114,6 +126,10 @@ const HomePage = () => {
 
 	if (isError) {
 		console.error(error);
+	}
+
+	if (isTargetTimeError) {
+		console.error(targetTimeError);
 	}
 
 	return (
@@ -198,7 +214,7 @@ const HomePage = () => {
 							</SVGBtn>
 						</div>
 						<TodayTodoBox
-							time={0}
+							time={targetTime}
 							addingTodayTodoStatus={addingTodayTodoStatus}
 							selectedTodayTodos={todayTodos}
 							hasTodos={isTaskExist(dailyCategoryTask)}

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -30,18 +30,26 @@ const HomePage = () => {
 	const todayDate = dayjs().tz('Asia/Seoul');
 
 	const [selectedDate, setSelectedDate] = useState(todayDate);
+	const { startDate, endDate } = getThisWeekRange(selectedDate);
+
+	const { data: categoriesData, isError, error } = useGetAllCategoryTask(startDate, endDate);
+	const categories = categoriesData?.data || [];
+	const dailyCategoryTask = getDailyCategoryTask(selectedDate, categories);
+
+	const [addingTodayTodoStatus, setAddingTodayTodoStatus] = useState(false);
+	const addTodayTodoOverlayStyle = addingTodayTodoStatus ? 'opacity-30 pointer-events-none' : '';
+
+	const disableAddingTodayTodo = () => {
+		setAddingTodayTodoStatus(false);
+	};
+
+	const enableAddingTodayTodo = () => {
+		setAddingTodayTodoStatus(true);
+	};
 
 	const handleSelectedDateChange = (date: Dayjs) => {
 		setSelectedDate(date);
 	};
-
-	const { startDate, endDate } = getThisWeekRange(selectedDate);
-
-	const { data: categoriesData, isError, error } = useGetAllCategoryTask(startDate, endDate);
-
-	const categories = categoriesData?.data || [];
-
-	const dailyCategoryTask = getDailyCategoryTask(selectedDate, categories);
 
 	if (isError) {
 		console.error(error);
@@ -49,29 +57,33 @@ const HomePage = () => {
 
 	return (
 		<HomePageWrapper>
-			<HomeSideBar />
+			<div className={addTodayTodoOverlayStyle}>
+				<HomeSideBar />
+			</div>
 			<div className="flex h-full w-full justify-between p-[4.2rem]">
 				<section>
-					<div className="flex h-[11rem] items-center gap-[1.8rem] pt-[1.2rem]">
-						<UserProfile isMyProfile />
-						<ul className="flex gap-[1.8rem]">
-							<li>
-								<UserProfile isConnecting />
-							</li>
-							<li>
-								<UserProfile isConnecting />
-							</li>
-							<li>
-								<UserProfile isConnecting />
-							</li>
-						</ul>
-						<MoreFriendsBtn friendsCount={12} />
+					<div className={addTodayTodoOverlayStyle}>
+						<div className="flex h-[11rem] items-center gap-[1.8rem] pt-[1.2rem]">
+							<UserProfile isMyProfile />
+							<ul className="flex gap-[1.8rem]">
+								<li>
+									<UserProfile isConnecting />
+								</li>
+								<li>
+									<UserProfile isConnecting />
+								</li>
+								<li>
+									<UserProfile isConnecting />
+								</li>
+							</ul>
+							<MoreFriendsBtn friendsCount={12} />
+						</div>
+						<DatePicker
+							todayDate={todayDate}
+							selectedDate={selectedDate}
+							onSelectedDateChange={handleSelectedDateChange}
+						/>
 					</div>
-					<DatePicker
-						todayDate={todayDate}
-						selectedDate={selectedDate}
-						onSelectedDateChange={handleSelectedDateChange}
-					/>
 					<div className="flex">
 						<article className="flex h-[732px] w-[1262px] gap-[2.8rem] overflow-x-auto">
 							{dailyCategoryTask.length !== 0 ? (
@@ -111,7 +123,7 @@ const HomePage = () => {
 				</section>
 				<section className="flex items-end justify-end">
 					<div className="flex flex-col">
-						<div className="mb-[4.4rem] flex justify-end">
+						<div className={`mb-[4.4rem] flex justify-end ${addTodayTodoOverlayStyle}`}>
 							<SVGBtn>
 								<FriendSettingIcon className="rounded-[1.6rem] hover:bg-gray-bg-04 active:bg-gray-bg-05" />
 							</SVGBtn>
@@ -119,7 +131,14 @@ const HomePage = () => {
 								<BellIcon className="rounded-[1.6rem] hover:bg-gray-bg-04 active:bg-gray-bg-05" />
 							</SVGBtn>
 						</div>
-						<TodayTodoBox time={0} selectedTodayTodos={[]} hasTodos={isTaskExist(dailyCategoryTask)} />
+						<TodayTodoBox
+							time={0}
+							addingTodayTodoStatus={addingTodayTodoStatus}
+							selectedTodayTodos={[]}
+							hasTodos={isTaskExist(dailyCategoryTask)}
+							enableAddingTodayTodo={enableAddingTodayTodo}
+							disableAddingTodayTodo={disableAddingTodayTodo}
+						/>
 					</div>
 				</section>
 			</div>

--- a/src/types/home/index.tsx
+++ b/src/types/home/index.tsx
@@ -2,7 +2,7 @@ export interface Task {
 	id: number;
 	name: string;
 	startDate: string;
-	endDate: string;
+	endDate: string | null;
 	targetTime: number;
 	isComplete: true;
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #119 

## ✅ 작업 내용

- [x] 오늘의 할일이 없을 때, 기본화면을 보여주는 상태 연결
- [x] 오늘의 할일을 선택 취소 할 수 있는 상태 연결 
    - [x] 이 떄 날짜 변경할 수 없음 취소를 누르고 변경해야함
- [x] 오늘의 할일을 선택하고 완료하여 타이머 시작 전의 상태 연결
   - [x] 이 때 수정을 누르면 다시 오늘의 할일을 선택할 수 있어야함
- [x] 오늘의 할일을 클라이언트에서 상태로 관리하고 타이머를 시작했을 때 서버로 전달하는 API 연결

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/2c78a908-c5a8-437a-b0e6-c8d420ea6571

## 📌 이슈 사항

## ✍ 궁금한 것