### PR TITLE
[ Fix ] 김건휘 폴더 이름 이슈 수정 대소문자 구문

### DIFF
--- a/src/components/molecules/TimerSideBox/index.tsx
+++ b/src/components/molecules/TimerSideBox/index.tsx
@@ -1,0 +1,35 @@
+import SideBox from '@/components/atoms/SideBox';
+import TimerFavicon from '@/components/atoms/TimerFavicon';
+
+import AddBtnIcon from '@/assets/svgs/btn_add.svg?react';
+
+import { Favicon_DATA } from '@/mocks/faviconData';
+
+const TimerSideBox = () => {
+	return (
+		<SideBox>
+			<div className="flex w-[5.4rem] flex-col items-start bg-gray-bg-02">
+				<p className="detail-semibold-14 border-b-[0.1rem] border-b-gray-bg-05 py-[1.7rem] pl-[0.3rem] text-gray-04">
+					모립세트
+				</p>
+				<div>
+					<p className="detail-semibold-14 mt-[0.8rem] px-[1.2rem] py-[1.3rem] text-white">Web</p>
+					<ul>
+						{Favicon_DATA.map((item) => (
+							<li key={item.id} className="rounded-[1.6rem] px-[1.1rem] py-[1.1rem] hover:bg-gray-bg-04">
+								<TimerFavicon {...item} />
+							</li>
+						))}
+					</ul>
+					<AddBtnIcon />
+				</div>
+				<p className="detail-semibold-14 border-t-[0.1rem] border-t-gray-bg-05 py-[1.3rem] pl-[1.3rem] pr-[1.4rem] text-gray-04">
+					App
+				</p>
+				<AddBtnIcon />
+			</div>
+		</SideBox>
+	);
+};
+
+export default TimerSideBox;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 내용

- [x] 김건휘 폴더 이름 이슈 수정 대소문자 구문

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

### 깃은 기본적으로 파일, 폴더명 대소문자를 구문하지 못한다

그래서 다음 설정을 통해서 구분할수있게하였다

```
git config core.ignorecase false
```

<img width="715" alt="image" src="https://github.com/user-attachments/assets/1a417697-0fe9-451b-9432-f9aad68f6715">


## ✍ 궁금한 것