### PR TITLE
[ Fix ] 오늘 나의 몰입시간(accumulate Time) 2배로 증가하는 버그 해결

### DIFF
--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -65,13 +65,16 @@ const TimerPage = () => {
 	const targetTodoTitle = selectedTodoData?.name || '';
 	const targetCategoryTitle = selectedTodoData?.categoryName || '';
 
-	const { increasedTime } = useTimerCount({ isPlaying, previousTime: targetTime });
-
 	const {
 		timer: timerTime,
 		increasedTime: timerIncreasedTime,
 		resetIncreasedTime: resetTimerIncreasedTime,
 	} = useTimerCount({ isPlaying, previousTime: targetTime });
+
+	const { timer: accumulatedTime, resetIncreasedTime: resetAccumulatedIncreasedTime } = useTimerCount({
+		isPlaying,
+		previousTime: totalTimeOfToday,
+	});
 
 	useUrlHandler({
 		isPlaying,
@@ -79,7 +82,7 @@ const TimerPage = () => {
 		baseUrls,
 		stopTimer,
 		formattedTodayDate,
-		increasedTime,
+		timerIncreasedTime,
 		setIsPlaying,
 		getBaseUrl,
 	});
@@ -109,13 +112,14 @@ const TimerPage = () => {
 					</header>
 					<Timer
 						selectedTodo={selectedTodo}
-						totalTimeOfToday={totalTimeOfToday}
 						onPlayToggle={handlePlayToggle}
 						isPlaying={isPlaying}
 						formattedTodayDate={formattedTodayDate}
 						timerTime={timerTime}
 						timerIncreasedTime={timerIncreasedTime}
 						resetTimerIncreasedTime={resetTimerIncreasedTime}
+						accumulatedTime={accumulatedTime}
+						resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
 					/>
 					<Carousel />
 				</div>
@@ -141,6 +145,7 @@ const TimerPage = () => {
 								formattedTodayDate={formattedTodayDate}
 								resetTimerIncreasedTime={resetTimerIncreasedTime}
 								timerIncreasedTime={timerIncreasedTime}
+								resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
 							/>
 						</div>
 					</div>

--- a/src/pages/TimerPage/components/AccumulatedTime.tsx
+++ b/src/pages/TimerPage/components/AccumulatedTime.tsx
@@ -1,26 +1,10 @@
-import { useEffect } from 'react';
-
-import useTimerCount from '@/shared/hooks/useTimerCount';
-
 interface AccumulatedTimeProps {
-	isPlaying: boolean;
-	totalTimeOfToday: number;
+	accumulatedTime: number;
 }
 
-const AccumulatedTime = ({ isPlaying, totalTimeOfToday }: AccumulatedTimeProps) => {
-	const { timer, resetIncreasedTime } = useTimerCount({
-		isPlaying,
-		previousTime: totalTimeOfToday,
-	});
-
-	useEffect(() => {
-		if (!isPlaying) {
-			resetIncreasedTime();
-		}
-	}, [isPlaying, resetIncreasedTime]);
-
-	const hours = Math.floor(timer / 3600);
-	const minutes = Math.floor((timer % 3600) / 60);
+const AccumulatedTime = ({ accumulatedTime }: AccumulatedTimeProps) => {
+	const hours = Math.floor(accumulatedTime / 3600);
+	const minutes = Math.floor((accumulatedTime % 3600) / 60);
 
 	return (
 		<span className="head-bold-24 text-white">

--- a/src/pages/TimerPage/components/SideBarTimer.tsx
+++ b/src/pages/TimerPage/components/SideBarTimer.tsx
@@ -29,6 +29,7 @@ interface CategoryBoxProps {
 	resetTimerIncreasedTime: () => void;
 	timerIncreasedTime: number;
 	isSideOpen: boolean;
+	resetAccumulatedIncreasedTime: () => void;
 }
 
 const SideBarTimer = ({
@@ -43,6 +44,7 @@ const SideBarTimer = ({
 	resetTimerIncreasedTime,
 	timerIncreasedTime,
 	isSideOpen,
+	resetAccumulatedIncreasedTime,
 }: CategoryBoxProps) => {
 	const sidebarRef = useRef<HTMLDivElement>(null);
 	const navigate = useNavigate();
@@ -61,6 +63,7 @@ const SideBarTimer = ({
 							onPlayToggle(false);
 							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
 							resetTimerIncreasedTime();
+							resetAccumulatedIncreasedTime();
 						},
 					},
 				);

--- a/src/pages/TimerPage/components/Timer.tsx
+++ b/src/pages/TimerPage/components/Timer.tsx
@@ -10,7 +10,6 @@ import ProgressCircle from '@/pages/TimerPage/components/ProgressCircle';
 import TaskTime from '@/pages/TimerPage/components/TaskTime';
 
 interface TaskTotalTimeProps {
-	totalTimeOfToday: number;
 	selectedTodo: number | null;
 	onPlayToggle: (isPlaying: boolean) => void;
 	isPlaying: boolean;
@@ -18,10 +17,11 @@ interface TaskTotalTimeProps {
 	timerTime: number;
 	timerIncreasedTime: number;
 	resetTimerIncreasedTime: () => void;
+	accumulatedTime: number;
+	resetAccumulatedIncreasedTime: () => void;
 }
 
 const Timer = ({
-	totalTimeOfToday,
 	selectedTodo,
 	onPlayToggle,
 	isPlaying,
@@ -29,9 +29,11 @@ const Timer = ({
 	timerTime,
 	timerIncreasedTime,
 	resetTimerIncreasedTime,
+	accumulatedTime,
+	resetAccumulatedIncreasedTime,
 }: TaskTotalTimeProps) => {
 	const queryClient = useQueryClient();
-	const accumulatedTime = totalTimeOfToday || 0;
+
 	const { mutate, isError, error } = usePostTimerStop();
 
 	const handlePlayPauseToggle = () => {
@@ -43,6 +45,7 @@ const Timer = ({
 						onSuccess: () => {
 							onPlayToggle(false);
 							resetTimerIncreasedTime();
+							resetAccumulatedIncreasedTime();
 							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
 						},
 					},
@@ -63,7 +66,7 @@ const Timer = ({
 			<InnerCircleIcon className="absolute" />
 			<div className="absolute flex h-[22rem] w-[27.1rem] flex-col items-center justify-center">
 				<div className="flex flex-col items-center justify-center">
-					<AccumulatedTime isPlaying={isPlaying} totalTimeOfToday={accumulatedTime} />
+					<AccumulatedTime accumulatedTime={accumulatedTime} />
 					<TaskTime isPlaying={isPlaying} timer={timerTime} />
 				</div>
 				<div>

--- a/src/shared/hooks/useUrlHandler.ts
+++ b/src/shared/hooks/useUrlHandler.ts
@@ -8,7 +8,7 @@ interface UseUrlHandlerProps {
 		params: { id: number; elapsedTime: number; targetDate: string },
 		options: { onSuccess: () => void },
 	) => void;
-	increasedTime: number;
+	timerIncreasedTime: number;
 	setIsPlaying: (isPlaying: boolean) => void;
 	getBaseUrl: (url: string) => string;
 	formattedTodayDate: string;
@@ -19,7 +19,7 @@ const useUrlHandler = ({
 	selectedTodo,
 	baseUrls,
 	stopTimer,
-	increasedTime,
+	timerIncreasedTime,
 	setIsPlaying,
 	getBaseUrl,
 	formattedTodayDate,
@@ -33,7 +33,7 @@ const useUrlHandler = ({
 				setTimeout(() => {
 					if (isPlaying && selectedTodo !== null && !baseUrls.includes(updatedBaseUrl)) {
 						stopTimer(
-							{ id: selectedTodo, elapsedTime: increasedTime, targetDate: formattedTodayDate },
+							{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
 							{
 								onSuccess: () => {
 									setIsPlaying(false);
@@ -50,7 +50,7 @@ const useUrlHandler = ({
 		return () => {
 			document.removeEventListener('FROM_EXTENSION', handleMessage);
 		};
-	}, [increasedTime, isPlaying, selectedTodo, stopTimer, baseUrls, getBaseUrl, formattedTodayDate, setIsPlaying]);
+	}, [timerIncreasedTime, isPlaying, selectedTodo, stopTimer, baseUrls, getBaseUrl, formattedTodayDate, setIsPlaying]);
 };
 
 export default useUrlHandler;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #192 

## ✅ 작업 리스트

- [x] useEffect를 사용하지 않고 버그 해결

## 🔧 작업 내용
**컴포넌트 구조**
TImerPage(최상위)=> Timer => AccumulatedTime

**기존 AccumulatedTime 컴포넌트(총 몰입 시간을 보여주는 컴포넌트)**
<img width="535" alt="스크린샷 2024-09-13 오후 9 50 16" src="https://github.com/user-attachments/assets/3b2a8e1c-9d94-4e91-b754-ec641a270502">


```typescript
const AccumulatedTime = ({ isPlaying, totalTimeOfToday }: AccumulatedTimeProps) => {
	const { timer, resetIncreasedTime } = useTimerCount({
		isPlaying,
		previousTime: totalTimeOfToday,
	});

	useEffect(() => {
		if (!isPlaying) {
			resetIncreasedTime();
		}
	}, [isPlaying, resetIncreasedTime]);
```
기존에는 useEffect를 사용하여 isPlaying(타이머 재생 여부)이 바뀔 때 마다 resetIncreasedTime()을 호출하는 방식으로 increasedTime이 누적되는 것을 방지하였는데 useEffect를 사용하지 않고 해결하는 방법을 시도해보았습니다.

**1. TimerPage(최상단 페이지)**
```typescript
const { timer: accumulatedTime, resetIncreasedTime: resetAccumulatedIncreasedTime } = useTimerCount({
		isPlaying,
		previousTime: totalTimeOfToday,
	});
```
 totalTimeOfToday(오늘 총 몰입 시간)을 타이머가 작동할 때 +1씩 증겨시켜주는 useTimerCount훅을 사용한 로직을 최상단 컴포넌트인 TimerPage로 옮기고 ```timer(총 몰입 시간)```와 ```resetIncreasedTime(증가한 시간 초기화)```을 추출하여 props로 넘겨주었습니다. 

```typescript
<Timer
						selectedTodo={selectedTodo}
						onPlayToggle={handlePlayToggle}
						isPlaying={isPlaying}
						formattedTodayDate={formattedTodayDate}
						timerTime={timerTime}
						timerIncreasedTime={timerIncreasedTime}
						resetTimerIncreasedTime={resetTimerIncreasedTime}
						accumulatedTime={accumulatedTime}
						resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
					/>
```

**2. Timer.tsx**
```typescript
const handlePlayPauseToggle = () => {
		if (selectedTodo !== null) {
			if (isPlaying) {
				mutate(
					{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
					{
						onSuccess: () => {
							onPlayToggle(false);
							resetTimerIncreasedTime();
							resetAccumulatedIncreasedTime(); //추가된 부분
							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
						},
					},
				);
			} else {
				onPlayToggle(true);
			}
		}
	};
```
play버튼을 클릭하여 타이머가 정지되었을 때 호출하는 api의 ```onSucess```조건에 ```resetAccumulatedIncreasedTime()```을 추가해주었습니다.

+ 추가적으로 SideBarTimer.tsx에서 타이머 진행중일 때 다른 todo를 클릭할시 호출되는 api의 ```onSucess```조건에도 ```resetAccumulatedIncreasedTime()```을 추가해주어 올바르게 increasedTime이 reset될 수 있게 해주었습니다.
```typescript
const handleTodoClick = (id: number, time: number, name: string, categoryName: string) => {
		if (isPlaying) {
			if (selectedTodo !== null) {
				stopTimer(
					{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
					{
						onSuccess: () => {
							onPlayToggle(false);
							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
							resetTimerIncreasedTime();
							resetAccumulatedIncreasedTime();
						},
					},
				);
			}
		}
		resetTimerIncreasedTime();
		onTodoSelection(id, time, name, categoryName);
	};
```



## 🧐 새로 알게된 점
useEffect 사용을 최소화하여 예기치 못한 사이드 이팩트를 방지하자!
## 🤔 궁금한 점
더 좋은 방향이 있으면 피드백 부탁드립니다!
## 📸 스크린샷 / GIF / Link
