### PR TITLE
[ Fix ] 타이머 정지 액션 발생시 깜빡이는 문제 해결

### DIFF
--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useSelectedTodo } from '@/shared/hooks/useSelectedTodo';
 import useTimerCount from '@/shared/hooks/useTimerCount';
@@ -35,7 +35,7 @@ interface MoribSetData {
 interface Todo {
 	id: number;
 	name: string;
-	targetTime: string;
+	targetTime: number;
 	categoryName: string;
 }
 
@@ -50,7 +50,16 @@ const TimerPage = () => {
 	const { ongoingTodos, completedTodos } = splitTasksByCompletion(todos);
 
 	const [selectedTodo, setSelectedTodo] = useSelectedTodo(todos);
+
+	const [targetTime, setTargetTime] = useState(0);
+
 	const [isPlaying, setIsPlaying] = useState(false);
+
+	const selectedTodoData = todos.find((todo: Todo) => todo.id === selectedTodo);
+
+	useEffect(() => {
+		setTargetTime(selectedTodoData?.targetTime || 0);
+	}, [selectedTodoData]);
 
 	const { data: setData } = useGetMoribSet(selectedTodo || 0);
 	const urls = useMemo(() => setData?.data.map(({ url }: MoribSetData) => url.trim()) || [], [setData]);
@@ -59,11 +68,6 @@ const TimerPage = () => {
 		const mappedUrls = urls.map(getBaseUrl);
 		return [...mappedUrls, DEFAULT_URL];
 	}, [urls]);
-
-	const selectedTodoData = todos.find((todo: Todo) => todo.id === selectedTodo);
-	const targetTime = selectedTodoData?.targetTime || '';
-	const targetTodoTitle = selectedTodoData?.name || '';
-	const targetCategoryTitle = selectedTodoData?.categoryName || '';
 
 	const {
 		timer: timerTime,
@@ -95,6 +99,10 @@ const TimerPage = () => {
 		setIsPlaying(isPlaying);
 	};
 
+	const updateTargetTime = (newTime: number) => {
+		setTargetTime(newTime);
+	};
+
 	if (isLoading || error) {
 		return <div>{isLoading ? 'Loading...' : 'Error...'}</div>;
 	}
@@ -107,8 +115,8 @@ const TimerPage = () => {
 				</div>
 				<div className="ml-[56.6rem] mt-[-0.8rem]">
 					<header className="mt-[8.6rem] flex flex-col items-center gap-[1rem]">
-						<h1 className="title-semibold-64 text-white">{targetTodoTitle}</h1>
-						<h2 className="title-med-32 text-gray-04">{targetCategoryTitle}</h2>
+						<h1 className="title-semibold-64 text-white">{selectedTodoData?.name || ''}</h1>
+						<h2 className="title-med-32 text-gray-04">{selectedTodoData?.categoryName || ''}</h2>
 					</header>
 					<Timer
 						selectedTodo={selectedTodo}
@@ -120,6 +128,7 @@ const TimerPage = () => {
 						resetTimerIncreasedTime={resetTimerIncreasedTime}
 						accumulatedTime={accumulatedTime}
 						resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
+						updateTargetTime={updateTargetTime}
 					/>
 					<Carousel />
 				</div>
@@ -130,7 +139,7 @@ const TimerPage = () => {
 					<HamburgerIcon />
 				</button>
 				{isSidebarOpen && (
-					<div className={` ${isSidebarOpen ? 'absolute inset-0 z-10 bg-dim' : ''}`}>
+					<div className={`${isSidebarOpen ? 'absolute inset-0 z-10 bg-dim' : ''}`}>
 						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
 							<SideBarTimer
 								targetTime={targetTime}

--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -59,7 +59,7 @@ const TimerPage = () => {
 
 	useEffect(() => {
 		setTargetTime(selectedTodoData?.targetTime || 0);
-	}, [selectedTodoData]);
+	}, [selectedTodoData?.targetTime]);
 
 	const { data: setData } = useGetMoribSet(selectedTodo || 0);
 	const urls = useMemo(() => setData?.data.map(({ url }: MoribSetData) => url.trim()) || [], [setData]);

--- a/src/pages/TimerPage/components/Timer.tsx
+++ b/src/pages/TimerPage/components/Timer.tsx
@@ -19,6 +19,7 @@ interface TaskTotalTimeProps {
 	resetTimerIncreasedTime: () => void;
 	accumulatedTime: number;
 	resetAccumulatedIncreasedTime: () => void;
+	updateTargetTime: (newTime: number) => void;
 }
 
 const Timer = ({
@@ -31,6 +32,7 @@ const Timer = ({
 	resetTimerIncreasedTime,
 	accumulatedTime,
 	resetAccumulatedIncreasedTime,
+	updateTargetTime,
 }: TaskTotalTimeProps) => {
 	const queryClient = useQueryClient();
 
@@ -39,6 +41,8 @@ const Timer = ({
 	const handlePlayPauseToggle = () => {
 		if (selectedTodo !== null) {
 			if (isPlaying) {
+				updateTargetTime(timerTime);
+
 				mutate(
 					{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
 					{

--- a/src/shared/hooks/useTimerCount.ts
+++ b/src/shared/hooks/useTimerCount.ts
@@ -16,6 +16,10 @@ const useTimerCount = ({ isPlaying, previousTime }: UseTimerCountProps): UseTime
 	const timerIntervalId = useRef<ReturnType<typeof setInterval> | null>(null);
 
 	useEffect(() => {
+		setIncreasedTime(0);
+	}, [previousTime]);
+
+	useEffect(() => {
 		if (isPlaying) {
 			if (timerIntervalId.current === null) {
 				timerIntervalId.current = setInterval(() => {
@@ -42,7 +46,7 @@ const useTimerCount = ({ isPlaying, previousTime }: UseTimerCountProps): UseTime
 		setIncreasedTime(0);
 	};
 
-	const timer = isPlaying ? previousTime + increasedTime : previousTime;
+	const timer = previousTime + increasedTime;
 
 	return { timer, increasedTime, resetIncreasedTime };
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #197 

## ✅ 작업 리스트

- [x] TimerPage 컴포넌트에서 targetTime을 상태로 관리
- [x] 타이머를 멈출 때 updateTargetTime(newTargetTime)을 호출하여 targetTime을 업데이트
- [x] useTimerCount 훅에서 previousTime이 변경될 때마다 increasedTime을 재설정하도록 useEffect를 추가

## 🔧 작업 내용
### 문제점
타이머 정지 액션이 발생하면(타이머 정지 버튼을 클릭하면) 직전에 멈췄었던 시간이 잠깐 보이다가 update되는 사용자 경험을 저해하는 문제가 발생

https://github.com/user-attachments/assets/9a8697a3-bb99-44e2-a95c-6f9e63cb27af

**컴포넌트 구조 :``` TimerPage``` -> ```Timer``` -> ```TaskTime```**
### 문제의 원인
**```Timer```컴포넌트의 ```handlePlayPauseToggle```  => 타이머 정지 버튼 클릭시 호출되는 함수**
```typescript
const handlePlayPauseToggle = () => {
		if (selectedTodo !== null) {
			if (isPlaying) {
				updateTargetTime(timerTime);

				mutate(
					{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
					{
						onSuccess: () => {
							onPlayToggle(false);
							resetTimerIncreasedTime();
							resetAccumulatedIncreasedTime();
							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
						},
					},
				);
			} else {
				onPlayToggle(true);
			}
		}
	};
```
```TimerPage```(최상단 컴포넌트)에서 ```useTimerCount```을 사용하여 타이머의 현재 상태와 관련된 값과 함수를 받아오는 부분
```typescript
const {
		timer: timerTime,
		increasedTime: timerIncreasedTime,
		resetIncreasedTime: resetTimerIncreasedTime,
	} = useTimerCount({ isPlaying, previousTime: targetTime });
```

### ```useTimerCount.ts```(```targetTime```을 기준으로 카운트 +1초씩 증가시켜주는 커스텀 훅)에서 timer시간을 계산해주는 식
```typescript
const timer = isPlaying ? previousTime + increasedTime : previousTime;
```
1. 위의 코드에서 ```mutate```의 ```onSucess``` 조건문을 확인해보면 ```queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });```를 통해 ```todos``` 데이터가 새로고침되면서 ```targetTime```이 업데이트 된다. (이를 통해 ```targetTime```이 정지하였을 때의 시간을 업데이트 해줌)
2. 이에 따라 ```useGetTodoList```가 다시 실행되어 최신의 ```todos``` 데이터를 가져온다.(```todos``` 데이터에 ```targetTime```이 존재)
3. ```TimerPage```(최상단 컴포넌트)에서 리랜더링이 발생
4. 이로 인해 ```TimerPage```의 
```typescript
const {
		timer: timerTime,
		increasedTime: timerIncreasedTime,
		resetIncreasedTime: resetTimerIncreasedTime,
	} = useTimerCount({ isPlaying, previousTime: targetTime });
``` 
```useTimerCount```가 재실행이 된다.
5.  ```useTimerCount``` 코드 중```const timer = isPlaying ? previousTime + increasedTime : previousTime;```을 확인해보면 useTimerCount 훅(타이머를 +1초 씩 카운트 해주는 로직)은 ```previousTime(이전 targetTime)```을 사용하여 계산.
6. 컴포넌트가 리렌더링되면 React는 먼저 현재 상태와 props로 UI를 렌더링하고, 그 후에 비동기 데이터 페칭이 완료되면 상태가 업데이트되고 컴포넌트가 다시 리렌더링된다.
7. ```TimerPage```가 리렌더링된 후 새로운 ```targetTime```이 업데이트되기까지 비동기적으로 데이터를 서버에서 가져오기 때문에 일정 시간이 소요된다. 이로 인해 직전에 멈췄었던 시간(previous)로 ```timer```를 계산하여 직전에 멈췄었던 시간이 잠깐 보였다가 업데이트 되어 정지 액션 발생시 깜빡여서 보이는 문제가 발생.

### 해결 방법

### 1. TimerPage 컴포넌트에서 ```targetTime```을 상태로 관리
```targetTime```을 상태로 관리하여 언제든지 업데이트할 수 있도록 하였습니다.
```typescript
const [targetTime, setTargetTime] = useState('');
```
useEffect를 사용하여 selectedTodoData의 변경 시 targetTime을 업데이트
```typescript
useEffect(() => {
    setTargetTime(selectedTodoData?.targetTime || '');
  }, [selectedTodoData]);
```

### 2. 타이머를 멈출 때 ```updateTargetTime(newTargetTime)```을 호출하여 targetTime을 업데이트
```Timer``` 컴포넌트
```typescript
const handlePlayPauseToggle = () => {
		if (selectedTodo !== null) {
			if (isPlaying) {
				updateTargetTime(timerTime); // 추가된 부분

				mutate(
					{ id: selectedTodo, elapsedTime: timerIncreasedTime, targetDate: formattedTodayDate },
					{
						onSuccess: () => {
							onPlayToggle(false);
							resetTimerIncreasedTime();
							resetAccumulatedIncreasedTime();
							queryClient.invalidateQueries({ queryKey: ['todo', formattedTodayDate] });
						},
					},
				);
			} else {
				onPlayToggle(true);
			}
		}
	};
```

### 3. ```useTimerCount``` 훅에서 ```previousTime```이 변경될 때마다 ```increasedTime```을 재설정하도록 ```useEffect```를 추가
```typescript
useEffect(() => {
		setIncreasedTime(0);
	}, [previousTime]);
```
추가적으로 ```useTimerCount```의 ```timer``` 계산에서 ```isPlaying ```여부와 관계없이 ```timer = previousTime + increasedTime```로 설정하여 항상 정확한 시간을 표시하도록 수정


## 🧐 새로 알게된 점
비동기 처리의 중요성을 느꼈습니다. 

## 🤔 궁금한 점
문제는 해결 되었지만 useEffect를 많이 사용한것 같습니다. 그러나 useEffect가 적절하게 사용되었다고 판단하는데 더 좋은 방향이나 피드백 있으면 코리 부탁드립니다.

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/29b8773d-faf8-43e6-8156-3126ec53247e


