### PR TITLE
[ Fix ] 모달 내 버그 해결 및 리팩토링

### DIFF
--- a/src/pages/HomePage/components/ModalAddCategory.tsx
+++ b/src/pages/HomePage/components/ModalAddCategory.tsx
@@ -177,7 +177,6 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	};
 
 	const handleSecondModalClose = () => {
-		handleClearData();
 		dialogRef.current?.close();
 	};
 

--- a/src/pages/HomePage/components/ModalAddCategory.tsx
+++ b/src/pages/HomePage/components/ModalAddCategory.tsx
@@ -59,7 +59,13 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	};
 
 	const handleAddTotalUrl = () => {
-		setTotalUrlInfos((prev) => [...prev, ...rightModalUrlInfos]);
+		setTotalUrlInfos((prev) => {
+			const existingUrls = new Set(prev.map((totalUrlInfo) => totalUrlInfo.url));
+
+			const newUrls = rightModalUrlInfos.filter((rightUrlInfo) => existingUrls.has(rightUrlInfo.url) === false);
+
+			return [...prev, ...newUrls];
+		});
 	};
 
 	const handleRightModalUrlInfos = (urlInfo: UrlInfo) => {

--- a/src/pages/HomePage/components/ModalAddCategory.tsx
+++ b/src/pages/HomePage/components/ModalAddCategory.tsx
@@ -34,6 +34,8 @@ interface ModalAddCategoryProps {
 const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	const [totalUrlInfos, setTotalUrlInfos] = useState<UrlInfo[]>([]);
 	const [rightModalUrlInfos, setRightModalUrlInfos] = useState<UrlInfo[]>([]);
+	const [isUrlValidated, setIsUrlValidated] = useState<boolean | null>(null);
+	const [inputUrl, setInputUrl] = useState('');
 
 	const [name, setName] = useState('');
 	const queryClient = useQueryClient();
@@ -56,6 +58,12 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 
 	const handleClearUrlInfos = () => {
 		setRightModalUrlInfos([]);
+	};
+	const handleUrlValidation = (state: boolean | null) => {
+		setIsUrlValidated(state);
+	};
+	const handleInputUrl = (url: string) => {
+		setInputUrl(url);
 	};
 
 	const handleAddTotalUrl = () => {
@@ -86,6 +94,8 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	const { error: queryError } = useGetTabName('');
 
 	const handleClearData = () => {
+		handleInputUrl('');
+		handleUrlValidation(null);
 		setName('');
 		setRightModalUrlInfos([]);
 		setTotalUrlInfos([]);
@@ -172,6 +182,8 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	};
 
 	const handlePostDataClick = () => {
+		handleUrlValidation(null);
+		handleInputUrl('');
 		handleClearData();
 		handleCategoryData();
 		handleCloseModal();
@@ -251,6 +263,10 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 						</button>
 						<ModalWrapper ref={dialogRef} backdrop={false}>
 							<AddCategoryListModal
+								inputUrl={inputUrl}
+								handleInputUrl={handleInputUrl}
+								isUrlValidated={isUrlValidated}
+								handleUrlValidation={handleUrlValidation}
 								handleSubmitModal={handleSecondModalSubmit}
 								handleSecondModalClose={handleSecondModalClose}
 								rightModalUrlInfos={rightModalUrlInfos}
@@ -261,6 +277,10 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 						</ModalWrapper>
 					</div>
 					<InputCategoryUrl
+						inputUrl={inputUrl}
+						handleInputUrl={handleInputUrl}
+						isUrlValidated={isUrlValidated}
+						handleUrlValidation={handleUrlValidation}
 						currentUrlInfos={totalUrlInfos}
 						variant="basic"
 						onUrlInputChange={(url: string) => handleUrlInputChange(url)}
@@ -286,7 +306,13 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 				>
 					취소
 				</ButtonCategoryCommon>
-				<ButtonCategoryCommon variant="완료" onClick={handlePostDataClick} disabled={!isFormValid()}>
+				<ButtonCategoryCommon
+					variant="완료"
+					onClick={() => {
+						handlePostDataClick();
+					}}
+					disabled={!isFormValid()}
+				>
 					완료
 				</ButtonCategoryCommon>
 			</div>

--- a/src/pages/HomePage/components/ModalAddCategory.tsx
+++ b/src/pages/HomePage/components/ModalAddCategory.tsx
@@ -1,6 +1,5 @@
 import React, { useRef, useState } from 'react';
 
-
 import { useQueryClient } from '@tanstack/react-query';
 
 import AddCategoryListModal from '@/shared/components/AddCategoryListModal';
@@ -161,15 +160,9 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 		showModal();
 	};
 
-	const handleClose = () => {
+	const handleSecondModalClose = () => {
 		handleClearData();
 		dialogRef.current?.close();
-
-	};
-
-	const handleCategoryModalClose = () => {
-		handleClearData();
-		handleCloseModal();
 	};
 
 	const handlePostDataClick = () => {
@@ -182,7 +175,7 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 		}
 	};
 
-	const handleMsetSubmit = () => {
+	const handleSecondModalSubmit = () => {
 		handleAddTotalUrl();
 		closeModal();
 	};
@@ -252,8 +245,8 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 						</button>
 						<ModalWrapper ref={dialogRef} backdrop={false}>
 							<AddCategoryListModal
-								handleSubmitModal={handleMsetSubmit}
-								handleClose={handleClose}
+								handleSubmitModal={handleSecondModalSubmit}
+								handleSecondModalClose={handleSecondModalClose}
 								rightModalUrlInfos={rightModalUrlInfos}
 								handleRightModalUrlInfos={handleRightModalUrlInfos}
 								handleDeleteUrlInfo={(url: UrlInfo) => handleDeleteUrlInfo(url)}
@@ -278,7 +271,13 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 			</main>
 
 			<div className="mt-[3rem] flex justify-end gap-[1.6rem]">
-				<ButtonCategoryCommon variant="취소" onClick={handleCategoryModalClose}>
+				<ButtonCategoryCommon
+					variant="취소"
+					onClick={() => {
+						handleClearData();
+						handleCloseModal();
+					}}
+				>
 					취소
 				</ButtonCategoryCommon>
 				<ButtonCategoryCommon variant="완료" onClick={handlePostDataClick} disabled={!isFormValid()}>

--- a/src/pages/HomePage/components/ModalAddCategory.tsx
+++ b/src/pages/HomePage/components/ModalAddCategory.tsx
@@ -34,7 +34,8 @@ interface ModalAddCategoryProps {
 const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 	const [totalUrlInfos, setTotalUrlInfos] = useState<UrlInfo[]>([]);
 	const [rightModalUrlInfos, setRightModalUrlInfos] = useState<UrlInfo[]>([]);
-	const [isUrlValidated, setIsUrlValidated] = useState<boolean | null>(null);
+	const [isFirstUrlValidated, setIsFirstUrlValidated] = useState<boolean | null>(null);
+	const [isSecondUrlValidated, setIsSecondUrlValidated] = useState<boolean | null>(null);
 	const [inputUrl, setInputUrl] = useState('');
 
 	const [name, setName] = useState('');
@@ -60,7 +61,8 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 		setRightModalUrlInfos([]);
 	};
 	const handleUrlValidation = (state: boolean | null) => {
-		setIsUrlValidated(state);
+		setIsFirstUrlValidated(state);
+		setIsSecondUrlValidated(state);
 	};
 	const handleInputUrl = (url: string) => {
 		setInputUrl(url);
@@ -264,7 +266,7 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 							<AddCategoryListModal
 								inputUrl={inputUrl}
 								handleInputUrl={handleInputUrl}
-								isUrlValidated={isUrlValidated}
+								isUrlValidated={isSecondUrlValidated}
 								handleUrlValidation={handleUrlValidation}
 								handleSubmitModal={handleSecondModalSubmit}
 								handleSecondModalClose={handleSecondModalClose}
@@ -278,7 +280,7 @@ const ModalAddCategory = ({ handleCloseModal }: ModalAddCategoryProps) => {
 					<InputCategoryUrl
 						inputUrl={inputUrl}
 						handleInputUrl={handleInputUrl}
-						isUrlValidated={isUrlValidated}
+						isUrlValidated={isFirstUrlValidated}
 						handleUrlValidation={handleUrlValidation}
 						currentUrlInfos={totalUrlInfos}
 						variant="basic"

--- a/src/shared/components/AddCategoryListModal.tsx
+++ b/src/shared/components/AddCategoryListModal.tsx
@@ -30,12 +30,12 @@ type CategoryListModalProp = {
 
 	handleDeleteUrlInfo: (url: UrlInfo) => void;
 	moribSetName: string;
-	handleClose: () => void;
+	handleSecondModalClose: () => void;
 };
 
 const AddCategoryListModal = ({
 	handleSubmitModal,
-	handleClose,
+	handleSecondModalClose,
 	rightModalUrlInfos,
 	handleRightModalUrlInfos,
 	handleDeleteUrlInfo,
@@ -160,7 +160,7 @@ const AddCategoryListModal = ({
 							variant="취소"
 							onClick={() => {
 								handleClearModalData();
-								handleClose();
+								handleSecondModalClose();
 								setCategoryId(0);
 							}}
 						>

--- a/src/shared/components/AddCategoryListModal.tsx
+++ b/src/shared/components/AddCategoryListModal.tsx
@@ -27,10 +27,13 @@ type CategoryListModalProp = {
 	handleSubmitModal: () => void;
 	rightModalUrlInfos: UrlInfo[];
 	handleRightModalUrlInfos: (url: UrlInfo) => void;
-
+	isUrlValidated: boolean | null;
+	handleUrlValidation: (state: boolean | null) => void;
 	handleDeleteUrlInfo: (url: UrlInfo) => void;
 	moribSetName: string;
 	handleSecondModalClose: () => void;
+	inputUrl: string;
+	handleInputUrl: (url: string) => void;
 };
 
 const AddCategoryListModal = ({
@@ -40,6 +43,10 @@ const AddCategoryListModal = ({
 	handleRightModalUrlInfos,
 	handleDeleteUrlInfo,
 	moribSetName,
+	isUrlValidated,
+	handleUrlValidation,
+	inputUrl,
+	handleInputUrl,
 }: CategoryListModalProp) => {
 	const [isClicked, setIsClicked] = useState(false);
 	const [selectedOption, setSelectedOption] = useState('카테고리 추가');
@@ -82,6 +89,9 @@ const AddCategoryListModal = ({
 	};
 
 	const handleClearModalData = () => {
+		setCategoryId(0);
+		handleUrlValidation(null);
+		handleInputUrl('');
 		setIsClicked(false);
 		setSelectedOption('카테고리 추가');
 	};
@@ -137,6 +147,10 @@ const AddCategoryListModal = ({
 					<TitleMoribSet moribSetName={moribSetName} />
 
 					<InputCategoryUrl
+						inputUrl={inputUrl}
+						handleInputUrl={handleInputUrl}
+						isUrlValidated={isUrlValidated}
+						handleUrlValidation={handleUrlValidation}
 						currentUrlInfos={rightModalUrlInfos}
 						variant="small"
 						onUrlInputChange={(url: string) => handleUrlInputChange(url)}
@@ -161,7 +175,6 @@ const AddCategoryListModal = ({
 							onClick={() => {
 								handleClearModalData();
 								handleSecondModalClose();
-								setCategoryId(0);
 							}}
 						>
 							취소
@@ -171,7 +184,6 @@ const AddCategoryListModal = ({
 							onClick={() => {
 								handleClearModalData();
 								handleSubmitModal();
-								setCategoryId(0);
 							}}
 						>
 							완료

--- a/src/shared/components/DropdownCategory.tsx
+++ b/src/shared/components/DropdownCategory.tsx
@@ -1,9 +1,11 @@
-import { ButtonHTMLAttributes } from 'react';
+import { ButtonHTMLAttributes, useRef } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
 import ButtonCategoryDropdown from '@/shared/components/ButtonCategoryDropdown';
 import ButtonDropdownOptions from '@/shared/components/ButtonDropdownOptions';
+
+import useClickOutside from '@/shared/hooks/useClickOutside';
 
 interface DropdownBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	optionData: Category[];
@@ -42,6 +44,8 @@ const DropdownCategory = ({
 
 		handleClickButton(!prev);
 	};
+	const dropdownRef = useRef<HTMLUListElement>(null);
+	useClickOutside(dropdownRef, () => handleClickButton(false), isClicked);
 
 	return (
 		<>
@@ -52,7 +56,10 @@ const DropdownCategory = ({
 				selectedOption={selectedOption}
 			/>
 			{isClicked && (
-				<ul className="absolute top-[5.6rem] max-h-[41.4rem] w-[27.2rem] flex-col overflow-scroll rounded-[5px] shadow-[0_3px_30px_0_rgba(0,0,0,0.40)]">
+				<ul
+					ref={dropdownRef}
+					className="absolute top-[5.6rem] max-h-[41.4rem] w-[27.2rem] flex-col overflow-scroll rounded-[5px] shadow-[0_3px_30px_0_rgba(0,0,0,0.40)]"
+				>
 					{optionData?.map((item) => {
 						return (
 							<li

--- a/src/shared/components/InputCategoryUrl.tsx
+++ b/src/shared/components/InputCategoryUrl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { isUrlValid } from '@/shared/utils/isUrlValid/index';
 
@@ -14,11 +14,21 @@ interface InputCategoryUrlProps {
 	variant?: 'basic' | 'small';
 	onUrlInputChange: (url: string) => void;
 	currentUrlInfos?: UrlInfo[];
+	isUrlValidated: boolean | null;
+	handleUrlValidation: (state: boolean | null) => void;
+	inputUrl: string;
+	handleInputUrl: (url: string) => void;
 }
 
-const InputCategoryUrl = ({ variant = 'basic', onUrlInputChange, currentUrlInfos }: InputCategoryUrlProps) => {
-	const [url, setUrl] = useState('');
-	const [isUrlValidated, setIsUrlValidated] = useState<boolean | null>(null);
+const InputCategoryUrl = ({
+	variant = 'basic',
+	onUrlInputChange,
+	currentUrlInfos,
+	isUrlValidated,
+	handleUrlValidation,
+	inputUrl,
+	handleInputUrl,
+}: InputCategoryUrlProps) => {
 	const [errorMessage, setErrorMessage] = useState<string>('');
 
 	const sizeVariantWidth = {
@@ -29,29 +39,18 @@ const InputCategoryUrl = ({ variant = 'basic', onUrlInputChange, currentUrlInfos
 	const defaultStyle = `subhead-med-18 h-[4.6rem] rounded-[8px] border-[1px] bg-gray-bg-02 px-[2rem] py-[1rem] text-white placeholder-gray-03 focus:outline-none ${sizeVariantWidth[variant]}`;
 	const borderStyle = isUrlValidated === false ? 'border-error-02' : 'border-transparent';
 
-	useEffect(() => {
-		if (isUrlValidated === false) {
-			const timer = setTimeout(() => {
-				setUrl('');
-				setIsUrlValidated(true);
-			}, 3000);
-
-			return () => clearTimeout(timer);
-		}
-	}, [isUrlValidated]);
-
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === 'Enter') {
-			const isValid = isUrlValid(url);
-			setIsUrlValidated(isValid);
+			const isValid = isUrlValid(inputUrl);
+			handleUrlValidation(isValid);
 			if (isValid) {
-				const isExist = currentUrlInfos?.some((info) => info.url === url);
+				const isExist = currentUrlInfos?.some((info) => info.url === inputUrl);
 				if (isExist) {
 					setErrorMessage('이미 추가된 주소입니다.');
-					setIsUrlValidated(false);
+					handleUrlValidation(false);
 				} else {
-					onUrlInputChange(url);
-					setUrl('');
+					onUrlInputChange(inputUrl);
+					handleInputUrl('');
 					setErrorMessage('알맞은 도메인을 입력해주세요.');
 				}
 			} else {
@@ -62,8 +61,8 @@ const InputCategoryUrl = ({ variant = 'basic', onUrlInputChange, currentUrlInfos
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const userInput = e.target.value;
-		setUrl(userInput);
-		setIsUrlValidated(null);
+		handleInputUrl(userInput);
+		handleUrlValidation(null);
 		setErrorMessage('');
 	};
 
@@ -74,7 +73,7 @@ const InputCategoryUrl = ({ variant = 'basic', onUrlInputChange, currentUrlInfos
 				placeholder="허용할 웹사이트 주소를 입력해 주세요."
 				className={`${defaultStyle} ${borderStyle}`}
 				onChange={handleChange}
-				value={url}
+				value={inputUrl}
 				onKeyDown={handleKeyDown}
 			/>
 			<div className={`flex h-[3.2rem] ${isUrlValidated === false ? 'visible' : 'invisible'}`}>

--- a/src/shared/components/TitleMoribSet.tsx
+++ b/src/shared/components/TitleMoribSet.tsx
@@ -7,7 +7,7 @@ const TitleMoribSet = ({ moribSetName }: TitleMoribSetProp) => {
 					moribSetName
 				) : (
 					<>
-						<h2 className="pr-[1rem]" /> _______ <span className="pr-[0.5rem]" />
+						<span className="pr-[1rem]" /> _______ <span className="pr-[0.5rem]" />
 					</>
 				)}
 			</h2>


### PR DESCRIPTION
## 🔥 Related Issues

- close #198 

## ✅ 작업 리스트

- [x]  InputUrl 컴포넌트 외부에서 에러 상태를 관리하도록 수정
- [x] 빠른 불러오기 모달(AddCategoryListModal) 들어갔다 나가면 상위 모달의 URL도 초기화가 되는 오류 수정
- [x] 빠른 불러오기 모달에서 중복을 검사할 때 상위 모달의 상태도 포함해서 검사해야하는 점 수정
- [x] 드롭다운 useClickOutside 적용

## 🔧 작업 내용
### 1️⃣ InputUrl 컴포넌트 외부에서 에러 상태를 관리하도록 수정
- inputUrl과 url이 유효인지 확인하는 isValidated 상태를 모달 최상단에서 관리하도록 수정 -> useEffect 삭제
- 완료, 취소 버튼 클릭시 input창과 isValidated 상태 모두 초기화 되도록 수정

### 2️⃣ 빠른 불러오기 모달(AddCategoryListModal) 들어갔다 나가면 상위 모달의 URL도 초기화가 되는 오류 수정
- 모달 close하는 함수 수정
- 빠른 불러오기 모달의 취소 버튼 handleSecondModalClose() 함수에서 handleClearData 함수 삭제 후 해결
첫번째 모달
```typescript
  <ButtonCategoryCommon
	variant="취소"
	onClick={() => {
		handleClearData();
		handleCloseModal();
		}}
>
	 취소
</ButtonCategoryCommon>
<ButtonCategoryCommon
	variant="완료"
	onClick={() => {
		handlePostDataClick();
	}}
disabled={!isFormValid()}
>
       완료
</ButtonCategoryCommon>
```

두번째 빠른 불러오기 모달
```typescript
<ButtonCategoryCommon
	variant="취소"
	onClick={() => {
	handleClearModalData();
	handleSecondModalClose();
	}}
>
	취소
</ButtonCategoryCommon>
<ButtonCategoryCommon
	variant="완료"
	onClick={() => {
	   handleClearModalData();
	   handleSubmitModal();
		}}
>
	완료
</ButtonCategoryCommon>
```

### 3️⃣ 빠른 불러오기 모달에서 중복을 검사할 때 상위 모달의 상태도 포함해서 검사해야하는 점 수정
- Total url과 right modal의 url이 합쳐질 때 중복인 것은 제외되도록 다음과 같이 수정
```typescript
const handleAddTotalUrl = () => {
		setTotalUrlInfos((prev) => {
			const existingUrls = new Set(prev.map((totalUrlInfo) => totalUrlInfo.url));

			const newUrls = rightModalUrlInfos.filter((rightUrlInfo) => existingUrls.has(rightUrlInfo.url) === false);

			return [...prev, ...newUrls];
		});
	};
```

### 4️⃣ 드롭다운 useClickOutside 적용
- useClickOutside 적용해서 드롭다운 바깥쪽 클릭시 닫히도록 함


## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
- 빠른 불러오기 모달(AddCategoryListModal) 들어갔다 나가면 상위 모달의 URL도 초기화가 되는 오류 해결

https://github.com/user-attachments/assets/3b2046f5-1700-4bb7-bd48-b58ec33a4f9e

- 빠른 불러오기 모달에서 중복을 검사할 때 상위 모달의 상태도 포함해서 검사해야하는 점 수정
( 슬래시/ 여부 주의..)

https://github.com/user-attachments/assets/6aec3934-afd5-4642-afc8-e25a503266b9


- 에러메세지 뜬 채로 모달 창 나갔다 들어오면 에러메세지랑 input창 남아있던 오류 해결

https://github.com/user-attachments/assets/85887378-9a09-4ccf-aeae-86dd6efcbbc5


- 드롭다운 바깥 쪽 클릭시 드롭다운 닫히도록 함

https://github.com/user-attachments/assets/6b5d514c-37ef-4b3f-b215-436a88719e6a


