### PR TITLE
[Feat] 페이지 코드 스플릿팅 

### DIFF
--- a/src/pages/HomePage/components/StatusAddBoxTodayTodo.tsx
+++ b/src/pages/HomePage/components/StatusAddBoxTodayTodo.tsx
@@ -32,6 +32,11 @@ const StatusAddBoxTodayTodo = ({
 	//Todo: 선택된 Todo들을 취소하고 다시 추가하는 로직 추가
 	const hasTodayTodos = !(selectedTodayTodos.length === 0);
 	const clickable = addingComplete ? '' : 'pointer-events-none cursor-default ';
+	const handleMouseEnter = () => {
+		import('@/pages/TimerPage/TimerPage').catch((error) => {
+			console.error('타이머 페이지를 받아오는데 오류가 발생했습니다.', error);
+		});
+	};
 
 	return (
 		<div className="flex flex-grow flex-col justify-between">
@@ -77,7 +82,12 @@ const StatusAddBoxTodayTodo = ({
 					<HomeSmallBtn onClick={onDisableAddStatus}>{SMALL_BTN_TEXT.CANCEL}</HomeSmallBtn>
 				)}
 				<div className={clickable}>
-					<HomeLargeBtn variant={HomeLargeBtnVariant.LARGE} disabled={!addingComplete} onClick={onCreateTodayTodos}>
+					<HomeLargeBtn
+						variant={HomeLargeBtnVariant.LARGE}
+						disabled={!addingComplete}
+						onClick={onCreateTodayTodos}
+						onMouseEnter={handleMouseEnter}
+					>
 						{LARGE_BTN_TEXT.START_TIMER}
 					</HomeLargeBtn>
 				</div>

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -26,6 +26,12 @@ const LoginPage = () => {
 		window.location.href = API_URL;
 	};
 
+	const handleMouseEnter = () => {
+		import('@/pages/HomePage/HomePage').catch((error) => {
+			console.error('홈페이지를 받아오는데 오류가 발생했습니다.', error);
+		});
+	};
+
 	return (
 		<LoginPageWrapper>
 			<div className="h-[37rem] w-[60rem]">
@@ -44,6 +50,7 @@ const LoginPage = () => {
 				/>
 				{/* Todo: 추후 로그인 로직 추가 */}
 				<ButtonSVG
+					onMouseEnter={handleMouseEnter}
 					onClick={handleClick}
 					className={`ml-[12rem] transition-opacity duration-300 ${isAnimationComplete ? 'opacity-100' : 'opacity-0'}`}
 				>

--- a/src/pages/TimerPage/components/SideBarTimer.tsx
+++ b/src/pages/TimerPage/components/SideBarTimer.tsx
@@ -89,6 +89,12 @@ const SideBarTimer = ({
 		}
 	};
 
+	const handleMouseEnter = () => {
+		import('@/pages/HomePage/HomePage').catch((error) => {
+			console.error('홈페이지를 받아오는데 오류가 발생했습니다.', error);
+		});
+	};
+
 	if (isError) {
 		console.error(error);
 	}
@@ -135,7 +141,7 @@ const SideBarTimer = ({
 			</div>
 			<div className="flex flex-col items-start gap-[1rem] pb-[2rem] pt-[4rem]">
 				<ButtonSideBar variant="할 일 추가">할 일 추가</ButtonSideBar>
-				<ButtonSideBar variant="홈으로 나가기" onClick={handleNavigateHome}>
+				<ButtonSideBar variant="홈으로 나가기" onClick={handleNavigateHome} onMouseEnter={handleMouseEnter}>
 					홈으로 나가기
 				</ButtonSideBar>
 			</div>

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,14 +1,16 @@
 import type { Router } from '@remix-run/router';
 
+import { Suspense, lazy } from 'react';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
 import HomePage from '@/pages/HomePage/HomePage';
-import LoginPage from '@/pages/LoginPage';
 import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
 import TimerPage from '@/pages/TimerPage/TimerPage';
 
 import RedirectPage from '../pages/RedirectPage';
 import { ROUTES_CONFIG } from './routesConfig';
+
+const LoginPage = lazy(() => import('@/pages/LoginPage'));
 
 const ProtectedRoute = () => {
 	//Todo: 개발이 진행되면 실제 토큰 상태를 받아서 login page로 이동 시킴
@@ -28,7 +30,11 @@ const router: Router = createBrowserRouter([
 		children: [
 			{
 				path: ROUTES_CONFIG.login.path,
-				element: <LoginPage />,
+				element: (
+					<Suspense fallback={<div>Loading...</div>}>
+						<LoginPage />
+					</Suspense>
+				),
 			},
 			{
 				path: ROUTES_CONFIG.redirect.path,

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -3,14 +3,14 @@ import type { Router } from '@remix-run/router';
 import { Suspense, lazy } from 'react';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
-import HomePage from '@/pages/HomePage/HomePage';
 import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
-import TimerPage from '@/pages/TimerPage/TimerPage';
 
 import RedirectPage from '../pages/RedirectPage';
 import { ROUTES_CONFIG } from './routesConfig';
 
 const LoginPage = lazy(() => import('@/pages/LoginPage'));
+const HomePage = lazy(() => import('@/pages/HomePage/HomePage'));
+const TimerPage = lazy(() => import('@/pages/TimerPage/TimerPage'));
 
 const ProtectedRoute = () => {
 	//Todo: 개발이 진행되면 실제 토큰 상태를 받아서 login page로 이동 시킴
@@ -50,11 +50,19 @@ const router: Router = createBrowserRouter([
 		children: [
 			{
 				path: ROUTES_CONFIG.home.path,
-				element: <HomePage />,
+				element: (
+					<Suspense fallback={<div>Loading...</div>}>
+						<HomePage />
+					</Suspense>
+				),
 			},
 			{
 				path: ROUTES_CONFIG.timer.path,
-				element: <TimerPage />,
+				element: (
+					<Suspense fallback={<div>Loading...</div>}>
+						<TimerPage />
+					</Suspense>
+				),
 			},
 		],
 	},


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #204

## ✅ 작업 리스트

- [x] 페이지 코드 스플릿팅 

## 🔧 작업 내용

`Login 페이지`에서 사용되는 `lottie` 번들이 `Home 페이지`에서도 불러와져 큰 용량을 차지하고 있었습니다. 로그인 페이지를  하나의 번들로 분리하고, `Login 페이지`에서만 `lottie`가 사용되도록 코드 스플릿팅을 진행했습니다. Lazy, Suspend 사용으로 동적으로 컴포넌트를 불러와 번들의 크기를 줄이고, 초기 렌더링에서 사용되지 않는 컴포넌트의 로딩을 지연시킴으로써 페이지 성능을 최적화 하였습니다. 

### Router.tsx
```javascript
const LoginPage = lazy(() => import('@/pages/LoginPage'));

```
`LoginPage`에서 동적 import를 활용해 모듈을 비동기적으로 로드할 수 있도록 `lazy`를 추가합니다. 
```javascript
const router: Router = createBrowserRouter([
	{
		//public 라우트들
		path: '/',
		element: <Outlet />,
		children: [
			{
				path: ROUTES_CONFIG.login.path,
				element: (
					<Suspense fallback={<div>Loading...</div>}>
						<LoginPage />
					</Suspense>
				),
			},
			/.../
		],
	},
```
`
동적 import를 통해 `LoginPage`가 로드되며, 그 동안 `Suspense`의 fallback prop에 지정된 UI 요소가 화면에 표시됩니다.

### LoginPage/index.tsx
```javascript
	const handleMouseEnter = () => {
		import('@/pages/HomePage/HomePage').catch((error) => {
			console.error('홈페이지를 받아오는데 오류가 발생했습니다.', error);
		});
	};
```

LoginPage에서 로그인 버튼에 `mouseover` 될 때, HomePage 요소가 `preload` 되도록 `handleMouseEnter`를 추가했습니다. 

```javascript
	return (
				<ButtonSVG
					onMouseEnter={handleMouseEnter}
					onClick={handleClick}
					className={`ml-[12rem] transition-opacity duration-300 ${isAnimationComplete ? 'opacity-100' : 'opacity-0'}`}
				>
					<GoogleLoginIcon />
				</ButtonSVG>
```
`ButtonSVG`에 `onMouseEnter={handleMouseEnter}` 속성을 추가해 두었습니다. 

구체적인 성능 개선 수치는 아래에 정리해 두었습니다! 
https://www.notion.so/1282109060f4800483abfa3d015be1cc?pvs=4

## 🧐 새로 알게된 점
- `Lazy`, 'Suspense` 사용에 대한 개념적 이해를 얻었습니다. 
- 네트워크 탭, 퍼포먼스 탭, lighthouse 사용을 통해 성능을 개선시키는 경험을 하였습니다. 

## 🤔 궁금한 점
- 로그인 페이지에 Lazy를 적용하고 나니 Lottie Animation이 ButtonSVG보다 늦게 불러와 지는 걸 발견했습니다. 네트워크 속도를 3G로 변경해 보았을 때, 콘텐츠 다운로드 속도는 개선되었으나 queue 시작 시점이 3-4초 가량 늦어지는 문제가 있습니다. 
#### 수정 전
![image](https://github.com/user-attachments/assets/284093d6-2f6f-4b7d-b07b-d8162cefacea)
#### 수정 후 
![image](https://github.com/user-attachments/assets/3a0687b3-7696-4fce-b076-13f2ce21c37a)


-  첫 페이지를 불러올 때 로그인 페이지가 불러와지기 전까지  Suspense 사용으로  Loading 이라는 문구가 나타나도록 설정해 두었습니다. 모립의 첫 화면인데, Lottie-animation이 나타나기 전에 짧은 순간이라도 Loading이 나타나도록 하는 구현이 맞을지 고민이 되었습니다.
 
## 📸 스크린샷 / GIF / Link

