### PR TITLE
[ Feat ] 타이머 페이지 사이드바 동작 개선 및 반응형 적용

### DIFF
--- a/src/components/templates/HomePageWrapper/index.tsx
+++ b/src/components/templates/HomePageWrapper/index.tsx
@@ -5,7 +5,7 @@ interface HomePageWrapper {
 }
 
 const HomePageWrapper = ({ children }: HomePageWrapper) => {
-	return <div className="flex h-[1080px] w-[1920px] bg-gray-bg-01">{children}</div>;
+	return <div className="flex min-h-screen w-screen bg-gray-bg-01">{children}</div>;
 };
 
 export default HomePageWrapper;

--- a/src/components/templates/LoginPageWrapper/index.tsx
+++ b/src/components/templates/LoginPageWrapper/index.tsx
@@ -1,23 +1,11 @@
 import { ReactNode } from 'react';
 
-import LoginBackground from '@/shared/assets/images/login_background.png';
-
 interface LoginPageWrapperProps {
 	children: ReactNode;
 }
 
 const LoginPageWrapper = ({ children }: LoginPageWrapperProps) => {
-	return (
-		<div
-			className={`h-[1080px] w-[1920px] pl-[64.5rem] pt-[36.1rem]`}
-			style={{
-				backgroundImage: `url(${LoginBackground})`,
-				backgroundSize: 'cover',
-			}}
-		>
-			{children}
-		</div>
-	);
+	return <div className="bg-login-bg flex h-screen items-center justify-center bg-cover">{children}</div>;
 };
 
 export default LoginPageWrapper;

--- a/src/components/templates/TimerPageTemplates/index.tsx
+++ b/src/components/templates/TimerPageTemplates/index.tsx
@@ -5,7 +5,7 @@ interface TimerPageTemplatesProps {
 }
 
 const TimerPageTemplates = ({ children }: TimerPageTemplatesProps) => {
-	return <div className="relative flex h-[108rem] w-[192rem] overflow-hidden bg-gray-bg-01">{children}</div>;
+	return <div className="relative flex h-screen w-screen overflow-hidden bg-gray-bg-01">{children}</div>;
 };
 
 export default TimerPageTemplates;

--- a/src/components/templates/TimerPageTemplates/index.tsx
+++ b/src/components/templates/TimerPageTemplates/index.tsx
@@ -5,7 +5,7 @@ interface TimerPageTemplatesProps {
 }
 
 const TimerPageTemplates = ({ children }: TimerPageTemplatesProps) => {
-	return <div className="flex h-[108rem] w-[192rem] bg-gray-bg-01">{children}</div>;
+	return <div className="relative flex h-[108rem] w-[192rem] overflow-hidden bg-gray-bg-01">{children}</div>;
 };
 
 export default TimerPageTemplates;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -42,7 +42,7 @@ import StatusDefaultHome from './components/StatusDefaultHome';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-//Todo: 에러 핸들링 및 로직 분리 리팩토링 필요
+//TODO: 반응형 구조를 크게 변경해야해서 추후 pr에서 반영
 const HomePage = () => {
 	const todayDate = dayjs().tz('Asia/Seoul');
 	const formattedTodayDate = todayDate.format('YYYY-MM-DD');
@@ -234,7 +234,7 @@ const HomePage = () => {
 						)}
 					</div>
 				</section>
-				<section className="flex items-end justify-end">
+				<section className="absolute right-[4.2rem] top-[15.2rem]">
 					<div className="flex flex-col">
 						<BoxTodayTodo
 							time={targetTime}

--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -138,27 +138,22 @@ const TimerPage = () => {
 				>
 					<HamburgerIcon />
 				</button>
-				{isSidebarOpen && (
-					<div className={`${isSidebarOpen ? 'absolute inset-0 z-10 bg-dim' : ''}`}>
-						<div className="absolute inset-y-0 right-0 flex justify-end overflow-hidden">
-							<SideBarTimer
-								targetTime={targetTime}
-								ongoingTodos={ongoingTodos}
-								completedTodos={completedTodos}
-								isSideOpen={isSidebarOpen}
-								toggleSidebar={handleSidebarToggle}
-								onTodoSelection={handleTodoSelection}
-								selectedTodo={selectedTodo}
-								onPlayToggle={handlePlayToggle}
-								isPlaying={isPlaying}
-								formattedTodayDate={formattedTodayDate}
-								resetTimerIncreasedTime={resetTimerIncreasedTime}
-								timerIncreasedTime={timerIncreasedTime}
-								resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
-							/>
-						</div>
-					</div>
-				)}
+
+				<SideBarTimer
+					targetTime={targetTime}
+					ongoingTodos={ongoingTodos}
+					completedTodos={completedTodos}
+					isSideOpen={isSidebarOpen}
+					toggleSidebar={handleSidebarToggle}
+					onTodoSelection={handleTodoSelection}
+					selectedTodo={selectedTodo}
+					onPlayToggle={handlePlayToggle}
+					isPlaying={isPlaying}
+					formattedTodayDate={formattedTodayDate}
+					resetTimerIncreasedTime={resetTimerIncreasedTime}
+					timerIncreasedTime={timerIncreasedTime}
+					resetAccumulatedIncreasedTime={resetAccumulatedIncreasedTime}
+				/>
 			</div>
 		</TimerPageTemplates>
 	);

--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -109,11 +109,13 @@ const TimerPage = () => {
 
 	return (
 		<TimerPageTemplates>
-			<div className="relative flex h-[108rem] w-[192rem] bg-[url('@/shared/assets/images/img_timer_bg.png')]">
-				<div className="absolute left-0">
+			<div className="flex">
+				<div className="absolute left-0 bg-slate-500">
 					<SideBoxTemporary />
 				</div>
-				<div className="ml-[56.6rem] mt-[-0.8rem]">
+				<div
+					className={`mt-[-0.8rem] flex w-screen min-w-[1080px] flex-col items-center justify-center transition-[padding-right] duration-300 ${isSidebarOpen ? 'pr-0 2xl:pr-[40.2rem]' : 'pr-0'}`}
+				>
 					<header className="mt-[8.6rem] flex flex-col items-center gap-[1rem]">
 						<h1 className="title-semibold-64 text-white">{selectedTodoData?.name || ''}</h1>
 						<h2 className="title-med-32 text-gray-04">{selectedTodoData?.categoryName || ''}</h2>
@@ -134,7 +136,7 @@ const TimerPage = () => {
 				</div>
 				<button
 					onClick={handleSidebarToggle}
-					className="ml-[38.2rem] mt-[3.2rem] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
+					className="absolute right-[32px] top-[32px] h-[5.4rem] w-[5.4rem] rounded-[1.5rem] hover:bg-gray-bg-04"
 				>
 					<HamburgerIcon />
 				</button>

--- a/src/pages/TimerPage/components/SideBarTimer.tsx
+++ b/src/pages/TimerPage/components/SideBarTimer.tsx
@@ -100,9 +100,7 @@ const SideBarTimer = ({
 	return (
 		<div
 			ref={sidebarRef}
-			className={`flex h-[108rem] w-[40.2rem] transform flex-col rounded-bl-[16px] rounded-tl-[16px] bg-gray-bg-03 pl-[1.8rem] ${
-				isSideOpen ? 'translate-x-0' : 'translate-x-full'
-			}`}
+			className={`absolute right-0 flex h-[108rem] w-[40.2rem] transform flex-col rounded-bl-[16px] rounded-tl-[16px] bg-gray-bg-03 pl-[1.8rem] transition-transform duration-300 ${isSideOpen ? 'translate-x-0' : 'translate-x-full'}`}
 		>
 			<div className="flex h-[5.4rem] w-[36.6rem] items-center justify-between pl-[0.2rem] pt-[2rem]">
 				<p className="head-bold-24 text-white">오늘 할 일</p>

--- a/src/pages/TimerPage/components/SideBarTimer.tsx
+++ b/src/pages/TimerPage/components/SideBarTimer.tsx
@@ -3,8 +3,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import useClickOutside from '@/shared/hooks/useClickOutside';
-
 import { usePatchTaskStatus } from '@/shared/apis/common/queries';
 import { usePostTimerStop } from '@/shared/apis/timer/queries';
 
@@ -93,14 +91,10 @@ const SideBarTimer = ({
 		console.error(error);
 	}
 
-	useClickOutside(sidebarRef, () => {
-		if (isSideOpen) toggleSidebar();
-	});
-
 	return (
 		<div
 			ref={sidebarRef}
-			className={`absolute right-0 flex h-[108rem] w-[40.2rem] transform flex-col rounded-bl-[16px] rounded-tl-[16px] bg-gray-bg-03 pl-[1.8rem] transition-transform duration-300 ${isSideOpen ? 'translate-x-0' : 'translate-x-full'}`}
+			className={`absolute right-0 flex h-full w-[40.2rem] transform flex-col rounded-bl-[16px] rounded-tl-[16px] bg-gray-bg-03 pl-[1.8rem] transition-transform duration-300 ${isSideOpen ? 'translate-x-0' : 'translate-x-full'}`}
 		>
 			<div className="flex h-[5.4rem] w-[36.6rem] items-center justify-between pl-[0.2rem] pt-[2rem]">
 				<p className="head-bold-24 text-white">오늘 할 일</p>

--- a/src/pages/TimerPage/components/SideBoxTemporary.tsx
+++ b/src/pages/TimerPage/components/SideBoxTemporary.tsx
@@ -7,7 +7,7 @@ import { Favicon_DATA } from '@/shared/mocks/faviconData';
 const SideBoxTemporary = () => {
 	return (
 		<SideBoxTimer>
-			<div className="flex w-[5.4rem] flex-col items-start bg-gray-bg-02">
+			<div className="flex h-screen w-[5.4rem] flex-col items-start bg-gray-bg-02">
 				<p className="detail-semibold-14 border-b-[0.1rem] border-b-gray-bg-05 py-[1.7rem] pl-[0.3rem] text-gray-04">
 					모립세트
 				</p>

--- a/src/pages/TimerPage/components/SideBoxTimer.tsx
+++ b/src/pages/TimerPage/components/SideBoxTimer.tsx
@@ -5,7 +5,7 @@ interface SideBoxTimerProps {
 }
 
 const SideBoxTimer = ({ children }: SideBoxTimerProps) => {
-	return <div className="h-[108rem] w-[7.4rem] bg-gray-bg-02 px-[1rem] pt-[0.6rem]">{children}</div>;
+	return <div className="h-screen w-[7.4rem] bg-gray-bg-02 px-[1rem] pt-[0.6rem]">{children}</div>;
 };
 
 export default SideBoxTimer;

--- a/src/pages/TimerPage/components/Timer.tsx
+++ b/src/pages/TimerPage/components/Timer.tsx
@@ -65,7 +65,7 @@ const Timer = ({
 	}
 
 	return (
-		<div className="mt-[8.2rem] flex items-center justify-center">
+		<div className="mt-[3.1rem] flex items-center justify-center">
 			<ProgressCircle isPlaying={isPlaying} timer={timerTime} />
 			<InnerCircleIcon className="absolute" />
 			<div className="absolute flex h-[22rem] w-[27.1rem] flex-col items-center justify-center">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ export default {
 				140: '140%',
 			},
 			backgroundImage: {
+				'login-bg': "url('@/shared/assets/images/login_background.png')",
 				'main-gra-01': 'linear-gradient(to right, #00F2C6, #A5FFFD)',
 				'main-gra-hover': 'linear-gradient(to right, #01DAB3, #92E6E4)',
 				'main-gra-press': 'linear-gradient(to right, #03C2A0, #80CCCA)',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #215

## ✅ 작업 리스트

- [x] 타이머 사이드바 동작 개선
- [x] 로그인, 타이머 뷰 반응형 적용

## 🔧 작업 내용

# 타이머 사이드바 동작 개선

- css에서 absolute 속성을 줄 때는, position이 relative인 가장 가까운 부모 태그의 위치에 따라서, 포지셔닝이 됩니다.
따라서 타이머 가장 `최상위 templates`에 relative를 주고 그 위치에 따라서 sidebar를 isSidebarOpen 상태에 따라 이동시켜주었어요.
따라서 useEffect를 사용할 필요없이 상태로 타이머바를 열고 닫을 수 있었습니다.

```javascript
const TimerPageTemplates = ({ children }: TimerPageTemplatesProps) => {
	return <div className="relative overflow-hidden ...">{children}</div>;
};
```

```javascript
<div
    ref={sidebarRef}
    className={`... right-0 ...
    transition-transform duration-300 ${isSideOpen ? 'translate-x-0' : 'translate-x-full'}`} >
```
- `translate-x-0` :  `right-0`의 위치 즉 `최상위 templates` 기준으로 맨 오른쪽에 위치


- `translate-x-full` : `right-사이드바의 width`의 위치 즉 `최상위 templates`을 넘어서 자기 width 만큼 오른쪽으로 떨어진 곳에 위치함
이 때 overflow-hidden이 `최상위 templates`에 적용되어있기 때문에 보이지 않음


# 반응형
- 먼저 홈페이지는 반응형 적용할 때 고려할 점이 많아서 따로 pr을 작성하여 반응형을 적용하겠습니다.

## 로그인

https://github.com/user-attachments/assets/78afda43-0c5d-4edb-b39a-a4f1416a67fa

- 최상위 템플릿에 w와 h를 화면의 뷰포트만큼 차지하게하고 (w-screen, h-screen),  justfy content center / align items center를 적용했어요

## 타이머 
```javascript
<div
	className={`mt-[-0.8rem] flex w-screen min-w-[1080px] flex-col items-center justify-center transition-[padding-right] duration-300 ${isSidebarOpen ? 'pr-0 2xl:pr-[40.2rem]' : 'pr-0'}`}
>
	<header ">
		<h1 className="title-semibold-64 text-white">{selectedTodoData?.name || ''}</h1>
		<h2 className="title-med-32 text-gray-04">{selectedTodoData?.categoryName || ''</h2>
	</header>
	<Timer/>
	<Carousel />
</div>
```
타이머 페이지 가운데 영역 `타이머와, 누적시간, 캐러셀을 감싸고 있는 div`에 **사이드 바가 열렸을 경우** 패딩값과 trasition 속성을 주어, 타이머 쪽 컴포넌트가 자연스럽게 밀리게 했어요.  이 때 `2xl:~` 는 tailwind 에서 제공하는 브레이크 포인트인데 2xl  1536px 이상일 때만  타이머쪽 컴포넌트가 밀리게 했습니다. ( 그 보다 화면이 작을 때 밀리게 되면 캐리 셀이 왼쪽 바를 침범하게 돼요)

나머지는 최상위 컴포넌트에 justify content / align item center를 주어 반응형을 고려했습니다.


https://github.com/user-attachments/assets/caef6f2c-e424-45aa-84d5-d82a64125ceb




## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
