### PR TITLE
[ Feat ] 온보딩 페이지 v2 api 를 연동합니다.

### DIFF
--- a/src/pages/OnboardingPage/StepService/AllowedServices/AllowedServices.tsx
+++ b/src/pages/OnboardingPage/StepService/AllowedServices/AllowedServices.tsx
@@ -54,14 +54,15 @@ const AllowedServiceItem = ({ siteUrl, siteName, onClick }: AllowedServiceItemPr
 	return (
 		<li className="flex h-[5.4rem] w-full items-center border-b border-b-gray-bg-04 px-[1rem] py-[1.2rem]">
 			<img src={getServiceFavicon(siteUrl)} alt={`${siteName} 아이콘`} className="h-[2rem] w-[2rem]" />
-			<h3 className="ml-[1.2rem] p-0 text-white body-med-16">{siteName}</h3>
-			<div className="ml-[4.2rem] h-[3.1rem] w-[23.1rem] truncate rounded-[20px] bg-gray-bg-04 px-[1rem] py-[0.6rem] text-gray-04 body-reg-16">
+			<h3 className="ml-[1.2rem] w-[6.6rem] flex-shrink-0 truncate p-0 text-white body-med-16">{siteName}</h3>
+			<div className="ml-[2.2rem] h-[3.1rem] w-[20.4rem] flex-shrink-0 truncate rounded-[20px] bg-gray-bg-04 px-[1rem] py-[0.6rem] text-gray-04 body-reg-16">
 				{siteUrl}
 			</div>
 			<button
 				onClick={() => {
 					onClick(siteUrl);
 				}}
+				className="flex-shrink-0"
 			>
 				<MinusIcon className="ml-[1.25rem]" />
 			</button>

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -1,6 +1,10 @@
 import { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import TextField from '@/shared/components/TextField/TextField';
+
+import { isUrlValid } from '@/shared/utils/isUrlValid';
+
 import type { PostInterestAreaReq } from '@/shared/types/api/onboarding';
 import type { FieldType } from '@/shared/types/fileds';
 
@@ -25,6 +29,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	const [activeTab, setActiveTab] = useState<FieldType>('비즈니스');
 	const [inputURL, setInputURL] = useState('');
 	const [selectedServices, setSelectedServices] = useState<PostInterestAreaReq['serviceList']>([]);
+	const [inputSuccess, setInputSuccess] = useState(false);
 
 	const navigate = useNavigate();
 
@@ -37,10 +42,10 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 		if (!url || isExist) return;
 
 		const response = await getUrlName({ url });
+		setInputSuccess(true);
 		const urlName = response?.data?.tabName;
 
 		setSelectedServices((prev) => [...prev, { siteName: urlName, siteUrl: url }]);
-		setInputURL('');
 	};
 
 	const handleRemoveSelectedService = (url: string) => {
@@ -48,6 +53,10 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	};
 
 	const handleChangeInputURL = (e: ChangeEvent<HTMLInputElement>) => {
+		if (inputSuccess) {
+			setInputSuccess(false);
+		}
+
 		setInputURL(e.target.value);
 	};
 
@@ -110,26 +119,21 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 						</Tabs.ContentList>
 					</Tabs>
 
-					<div className="mt-auto flex h-[6.6rem] shrink-0 items-center justify-between rounded-[8px] bg-gray-bg-02 py-[1rem] pl-[2rem] pr-[1rem]">
-						<input
-							value={inputURL}
-							onKeyDown={handleKeyDown}
-							onChange={handleChangeInputURL}
-							className="flex flex-grow bg-transparent text-gray-04 subhead-med-18 focus:outline-none"
-							placeholder="직접 url 입력하기"
-						/>
-						<button
-							onClick={() => handleAddSelectedService(inputURL)}
-							disabled={inputURL === ''}
-							className={`ml-[2rem] rounded-[5px] px-[2.2rem] py-[1.2rem] body-semibold-16 ${
-								inputURL
-									? 'bg-main-gra-01 text-gray-01 hover:bg-main-gra-hover active:bg-main-gra-press'
-									: 'bg-gray-bg-05 text-gray-04'
-							}`}
-						>
+					<TextField
+						value={inputURL}
+						onKeyDown={handleKeyDown}
+						onChange={handleChangeInputURL}
+						isError={inputURL.length > 0 && !isUrlValid(inputURL)}
+						errorMessage="알맞은 형식의 url을 입력해 주세요."
+						isSuccess={inputURL.length > 0 && inputSuccess}
+						successMessage="url 입력에 성공했어요."
+						placeholder="직접 url 입력하기"
+					>
+						<TextField.ClearButton onClick={() => setInputURL('')} />
+						<TextField.ConfirmButton disabled={inputURL === ''} onClick={() => handleAddSelectedService(inputURL)}>
 							등록하기
-						</button>
-					</div>
+						</TextField.ConfirmButton>
+					</TextField>
 				</div>
 			</main>
 

--- a/src/pages/OnboardingPage/StepService/Tabs/Tabs.tsx
+++ b/src/pages/OnboardingPage/StepService/Tabs/Tabs.tsx
@@ -13,7 +13,7 @@ const TabsContext = createContext<TabsContextProps | null>(null);
 const useTabsContext = () => {
 	const context = useContext(TabsContext);
 	if (!context) {
-		throw new Error('Tabs 컴포넌트는 <TabsRoot> 내부에서 사용되어야 합니다.');
+		throw new Error('Tabs 컴포넌트는 <Tabs> 내부에서 사용되어야 합니다.');
 	}
 	return context;
 };

--- a/src/pages/OnboardingPage/StepStart/StepStart.tsx
+++ b/src/pages/OnboardingPage/StepStart/StepStart.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import HomeLargeBtn from '@/shared/components/ButtonHomeLarge/ButtonHomeLarge';
 
 import { HomeLargeBtnVariant } from '@/shared/types/global';
@@ -9,6 +11,12 @@ interface StepStartProps {
 }
 
 const StepStart = ({ setStep }: StepStartProps) => {
+	const navigate = useNavigate();
+
+	const handleNavigateToHome = () => {
+		navigate('/home');
+	};
+
 	return (
 		<main className="flex w-full flex-col items-center justify-center">
 			<h1 className="mb-[2rem] text-center text-white title-bold-36">집중을 도와줄 모립세트를 만들어볼까요?</h1>
@@ -23,7 +31,9 @@ const StepStart = ({ setStep }: StepStartProps) => {
 				<span className="min-w-[15.6rem]">시작하기</span>
 			</HomeLargeBtn>
 
-			<button className="text-gray-04 subhead-reg-22">건너뛰기</button>
+			<button type="button" onClick={handleNavigateToHome} className="text-gray-04 subhead-reg-22">
+				건너뛰기
+			</button>
 		</main>
 	);
 };

--- a/src/pages/RedirectPage/RedirectPage.tsx
+++ b/src/pages/RedirectPage/RedirectPage.tsx
@@ -18,9 +18,9 @@ const RedirectPage = () => {
 			setAccessToken(accessToken);
 
 			if (isSignUp === 'true') {
-				navigate(`${ROUTES_CONFIG.home.path}`, { replace: true });
-			} else {
 				navigate(`${ROUTES_CONFIG.onboarding.path}?step=start`, { replace: true });
+			} else {
+				navigate(`${ROUTES_CONFIG.home.path}`, { replace: true });
 			}
 		}
 	}, [navigate, search]);

--- a/src/shared/apis/client.ts
+++ b/src/shared/apis/client.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-import { getAccessTotken } from '@/shared/utils/token';
-
+// import { getAccessTotken } from '@/shared/utils/token';
 import { ROUTES_CONFIG } from '@/router/routesConfig';
 
 // import { reissueToken } from './auth/axios';
@@ -27,16 +26,14 @@ const createBaseClient = (additionalConfig: AxiosRequestConfig = {}): AxiosInsta
 
 // 인증 설정을 추가하는 함수 (토큰)
 const addAuthInterceptor = (axiosClient: AxiosInstance) => {
-	axiosClient.interceptors.request.use(async (config) => {
-		const accessToken = getAccessTotken();
-		if (!accessToken) {
-			window.location.href = ROUTES_CONFIG.login.path;
-		}
-
-		config.headers.Authorization = `Bearer ${accessToken}`;
-		return config;
-	});
-
+	// axiosClient.interceptors.request.use(async (config) => {
+	// 	const accessToken = getAccessTotken();
+	// 	if (!accessToken) {
+	// 		window.location.href = ROUTES_CONFIG.login.path;
+	// 	}
+	// 	config.headers.Authorization = `Bearer ${accessToken}`;
+	// 	return config;
+	// });
 	// Todo: 서버 이슈로 앱잼 이후 refresh 토큰 재발급 설정
 	// axiosClient.interceptors.response.use(
 	// 	(response) => {

--- a/src/shared/apisV2/common/common.api.ts
+++ b/src/shared/apisV2/common/common.api.ts
@@ -1,10 +1,12 @@
-import axios from 'axios';
-
 import { GetUrlNameReq, GetUrlNameRes } from '@/shared/types/api/common';
 
-import { COMMON_MOCK_URL } from '@/mocks/common/common.resolvers';
+import { authClient } from '../client';
+
+export const COMMON_MOCK_URL = {
+	GET_URL_NAME: 'api/v2/tabName',
+};
 
 export const getUrlName = async ({ url }: GetUrlNameReq): Promise<GetUrlNameRes> => {
-	const { data } = await axios.get(`${COMMON_MOCK_URL.GET_URL_NAME}?tabName=${url}`);
+	const { data } = await authClient.get(COMMON_MOCK_URL.GET_URL_NAME, { params: { url } });
 	return data;
 };

--- a/src/shared/apisV2/onboarding/onboarding.api.ts
+++ b/src/shared/apisV2/onboarding/onboarding.api.ts
@@ -1,15 +1,16 @@
-import axios from 'axios';
-
 import { PostInterestAreaReq, PostInterestAreaRes } from '@/shared/types/api/onboarding';
 
-import { ONBOARDING_MOCK_URL } from '@/mocks/onboarding/onboarding.resolvers';
+import { authClient } from '../client';
 
-//NOTE: 쿼리스트링 형식 변경해주기
+export const ONBOARDING_URL = {
+	POST_INTEREST_AREA: 'api/v2/onboard',
+};
+
 export const postInterestArea = async ({
 	serviceList,
 	interestArea,
 }: PostInterestAreaReq): Promise<PostInterestAreaRes> => {
-	const { data } = await axios.post(ONBOARDING_MOCK_URL.POST_INTEREST_AREA, serviceList, {
+	const { data } = await authClient.post(ONBOARDING_URL.POST_INTEREST_AREA, serviceList, {
 		params: { interestArea },
 	});
 	return data;

--- a/src/shared/components/TextField/TextField.tsx
+++ b/src/shared/components/TextField/TextField.tsx
@@ -1,0 +1,122 @@
+import {
+	ButtonHTMLAttributes,
+	ChangeEvent,
+	InputHTMLAttributes,
+	KeyboardEvent,
+	ReactNode,
+	createContext,
+	useContext,
+} from 'react';
+
+import InputClearIcon from '@/shared/assets/svgs/btn_inputClear.svg?react';
+import SuccessIcon from '@/shared/assets/svgs/button_inputSuccess.svg?react';
+import FailIcon from '@/shared/assets/svgs/ic_description.svg?react';
+
+interface TextFieldContextProps {
+	isError?: boolean;
+}
+
+const TextFieldContext = createContext<TextFieldContextProps | null>(null);
+
+const useTextFieldContext = () => {
+	const context = useContext(TextFieldContext);
+	if (!context) {
+		throw new Error('TextField 컴포넌트는 <TextField> 내부에서 사용되어야 합니다.');
+	}
+	return context;
+};
+
+const TextFieldRoot = ({
+	isError,
+	errorMessage,
+	isSuccess,
+	successMessage,
+	onKeyDown,
+	children,
+	...props
+}: TextFieldRootProps) => {
+	const contextValue = {
+		isError,
+	};
+
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (isError) return;
+
+		onKeyDown && onKeyDown(e);
+	};
+
+	const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+		props.onChange && props.onChange(e);
+	};
+
+	return (
+		<TextFieldContext.Provider value={contextValue}>
+			<div
+				className={`relative mt-auto flex h-[6.6rem] shrink-0 items-center justify-between rounded-[8px] bg-gray-bg-02 py-[1rem] pl-[2rem] pr-[1rem] ${isError && 'border-[2px] border-error-02'} ${isSuccess && 'border-[2px] border-mint-01'} `}
+			>
+				<input
+					onKeyDown={handleKeyDown}
+					onChange={handleOnChange}
+					{...props}
+					className="flex flex-grow bg-transparent text-white subhead-med-18 placeholder:text-gray-04 focus:outline-none"
+				/>
+				{children}
+
+				{errorMessage && (
+					<div className={`absolute left-0 top-[7.65rem] gap-[0.5rem] ${isError && errorMessage ? 'flex' : 'hidden'} `}>
+						<FailIcon />
+						<p className="text-error-01 body-reg-16">{errorMessage}</p>
+					</div>
+				)}
+
+				{successMessage && (
+					<div className={`absolute left-0 top-[7.65rem] gap-[0.5rem] ${isSuccess ? 'flex' : 'hidden'} `}>
+						<SuccessIcon />
+						<p className="text-mint-01 body-reg-16">{successMessage}</p>
+					</div>
+				)}
+			</div>
+		</TextFieldContext.Provider>
+	);
+};
+
+const TextFieldClearButton = ({ ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => {
+	return (
+		<button {...props}>
+			<InputClearIcon />
+		</button>
+	);
+};
+
+const TextFieldConfirmButton = ({ ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => {
+	const { isError } = useTextFieldContext();
+
+	return (
+		<button
+			{...props}
+			disabled={isError || props.disabled}
+			className={`ml-[2rem] rounded-[5px] px-[2.2rem] py-[1.2rem] body-semibold-16 ${
+				!isError && !props.disabled
+					? 'bg-main-gra-01 text-gray-01 hover:bg-main-gra-hover active:bg-main-gra-press'
+					: 'bg-gray-bg-05 text-gray-04'
+			}`}
+		>
+			{props.children}
+		</button>
+	);
+};
+
+interface TextFieldRootProps extends InputHTMLAttributes<HTMLInputElement> {
+	isError?: boolean;
+	errorMessage?: string;
+	isSuccess?: boolean;
+	successMessage?: string;
+	children: ReactNode;
+}
+
+const TextField = Object.assign(TextFieldRoot, {
+	ClearButton: TextFieldClearButton,
+	ConfirmButton: TextFieldConfirmButton,
+});
+
+export default TextField;

--- a/src/shared/utils/isUrlValid/index.ts
+++ b/src/shared/utils/isUrlValid/index.ts
@@ -1,4 +1,4 @@
 export const isUrlValid = (url: string) => {
-	const isUrlValid = /^(http|https?:\/\/)?([\w\-]+\.)+[a-zA-Z]{2,}(\/[\w#!:.?+=&%@!\-\/]*)?$/;
-	return isUrlValid.test(url);
+	const urlPattern = /^(https?:\/\/)?([\w-]+(?:\.[\w-]+)+)(:[0-9]{1,5})?(\/[\w#!:.?+=&%@!\-/]*)?$/;
+	return urlPattern.test(url);
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] msw 주소를 실제 api 로 변경
- [x] api가 정상 작동하는지 테스트
- [x] 재사용 가능한 TextField 컴포넌트 생성 -> 모립세트 뷰 페이지에서 사용
- [x] input 에러 처리
- [x] isUrlValid 함수 정규식 오류 해결

## 🔧 작업 내용
- msw로 작업 했던 부분을 실제 api 주소로 바꾸어 바로 v2 api를 연동할 수 있었어요. msw 참 좋군요 ㅎㅎ
- 재사용 가능한 TextField 컴포넌트를 만들었어요. 이 때 컴파운드 컴포넌트 패턴으로 버튼의 유무 등을 선택적으로 사용할 수 있게 하여 재사용성을 높였어요.

! 현재 사용되지 않거나 바뀐 api 경로 때문에 빌드 오류가 뜨고 있는데 이 부분은 v2 api 모두 연동 후 해결 하려고합니다

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/f5b34bb7-c233-4a49-a4eb-709635ee5e0f

