### PR TITLE
[ Feat ] 레이지 로딩을 재적용 합니다.

### DIFF
--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -5,15 +5,16 @@ import { Outlet, createBrowserRouter } from 'react-router-dom';
 
 import AllowedServicePage from '@/pages/AllowedServicePage/AllowedServicePage';
 import HomePage from '@/pages/HomePage/HomePage';
-import LoginPage from '@/pages/LoginPage/LoginPage';
 import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
-import OnboardingPage from '@/pages/OnboardingPage/OnboardingPage';
-import RedirectPage from '@/pages/RedirectPage/RedirectPage';
-import TimerPage from '@/pages/TimerPage/TimerPage';
 import Layout from '@/shared/layout/Layout';
 
 import ProtectedRoute from './ProtectedRoute';
 import { ROUTES_CONFIG } from './routesConfig';
+
+const LoginPage = lazy(() => import('@/pages/HomePage/HomePage'));
+const RedirectPage = lazy(() => import('@/pages/RedirectPage/RedirectPage'));
+const OnboardingPage = lazy(() => import('@/pages/OnboardingPage/OnboardingPage'));
+const TimerPage = lazy(() => import('@/pages/TimerPage/TimerPage'));
 
 const router: Router = createBrowserRouter([
 	{


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #259 
## ✅ 작업 리스트

- [x] 레이지로딩 재적용

## 🔧 작업 내용
### 레이지 로딩을 재적용했어요
페이지가 추가됨에 따라서, 코드 스플릿팅이 필요한 지점을 다시 분석하고 적용하는게 필요하다고 생각했어요.

### light house 분석
먼저, 홈 페이지를 분석해보면 LCP랑 FCP가 상당히 높게 측정됐어요
> <img width="908" alt="image" src="https://github.com/user-attachments/assets/b23cf941-ed5f-4f7d-9d5b-479d1fa69da2" />
> <img width="1727" alt="image" src="https://github.com/user-attachments/assets/a31a05c8-efaa-48d9-97e5-a57814d65b73" />

coverage를 확인해보면 사용되지 않는 번들이 로드된 것으로 판단할 수 있어요. login 페이지에서 쓰이는 로티가 가장 큰 문제였어요

### 코드 스플릿팅하기
일단 홈 페이지와 허용서비스 페이지간 이동이 많기 때문에, 이 두 페이지를 코드 스플릿팅을 하면 페이지 진입 시 초기 로딩 성능에는 좋겠지만 오히려 사용자 경험에 좋지 않을 것이라고 판단하여 제외했어요. 
NotFound 페이지 또한 url을 잘못입력한 순간마다 로드되어야하기 때문에 코드스플릿팅에서 제외했어요.

이를 제외한 다른 페이지들은 특정 동작 이후에 실행되므로 코드 스플릿팅을 통해서 초기 성능을 높일 수 있을것 같아요.
<img width="686" alt="image" src="https://github.com/user-attachments/assets/c03cf886-b939-41fb-9eed-74ef87542dd3" />

### 적용 후
FCP가 3.3s -> 1.8s(50%) , LCP가 6.7s에서 3.4s(50%) 정도 개선되었어요.
최적화된 프로덕션 빌드 환경에서는 더 좋은 성능이 나올것이기 때문에 추후에 다시한번 확인 후 개선 작업을 진행하기로 했어요.
<img width="793" alt="image" src="https://github.com/user-attachments/assets/45cf2a46-8632-497b-9261-ec72b82227e3" />

### 타이머 페이지 로드 문제
> <img width="1728" alt="image" src="https://github.com/user-attachments/assets/da3a01bf-0157-40f7-9669-89ecaa452c5c" />

그럼 홈에서 코드 스플릿팅된 타이머 페이지로 이동할 때 로드 지연이 생길 위험이 있을것 같아요.
하지만 기존에 적용한 dynamic import를 사용해서 로드 지연을 개선할 수 있었어요.
```javascript
const handleMouseEnter = () => {
		import('@/pages/TimerPage/TimerPage').catch((error) => {
			console.error('타이머 페이지를 받아오는데 오류가 발생했습니다.', error);
		});
	};
	
<ButtonRadius5.Sm
		color="main"
		disabled={!addingComplete}
		onClick={onCreateTodayTodos}
		onMouseEnter={handleMouseEnter}
	>
		{LARGE_BTN_TEXT.START_TIMER}
</ButtonRadius5.Sm>
```


## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
