### PR TITLE
[ Style ] 홈 페이지 상단 반응형 일부를 수정합니다.

### DIFF
--- a/src/pages/HomePage/ButtonMoreFriends/ButtonMoreFriends.tsx
+++ b/src/pages/HomePage/ButtonMoreFriends/ButtonMoreFriends.tsx
@@ -8,9 +8,11 @@ interface ButtonMoreFriendsProps extends ButtonHTMLAttributes<HTMLButtonElement>
 
 const ButtonMoreFriends = ({ friendsCount, ...props }: ButtonMoreFriendsProps) => {
 	return (
-		<button className="relative mb-[2rem] h-[5.4rem] w-[5.4rem]" {...props}>
-			<ButtonMoreFriendIcon className="rounded-full hover:bg-gray-bg-04" />
-			<p className="absolute left-[1.4rem] top-[1.9rem] z-10 text-gray-04 subhead-med-18">+{friendsCount}</p>
+		<button className="relative mb-[2rem] h-[5.4rem]" {...props}>
+			<ButtonMoreFriendIcon className="absolute top-0 h-[5rem] w-[5rem] rounded-full hover:bg-gray-bg-04 2xl:h-[6rem] 2xl:w-[6rem]" />
+			<p className="absolute left-[1.2rem] top-[1.7rem] z-10 text-gray-04 body-med-16 2xl:left-[1.4rem] 2xl:top-[2.1rem] 2xl:subhead-med-18">
+				+{friendsCount}
+			</p>
 		</button>
 	);
 };

--- a/src/pages/HomePage/ButtonUserProfile/ButtonUserProfile.tsx
+++ b/src/pages/HomePage/ButtonUserProfile/ButtonUserProfile.tsx
@@ -20,11 +20,13 @@ const ButtonUserProfile = ({
 	return (
 		<button className="flex h-[8.2rem] w-[6rem] flex-col items-center">
 			<div className="flex flex-col">
-				<div className="relative h-[6rem] w-[6rem]">
-					{(isMyProfile || isSelectedUser) && <GradientCircleIcon />}
+				<div className="relative h-[5rem] w-[5rem] 2xl:h-[6rem] 2xl:w-[6rem]">
+					{(isMyProfile || isSelectedUser) && (
+						<GradientCircleIcon className="h-[5rem] w-[5rem] 2xl:h-[6rem] 2xl:w-[6rem]" />
+					)}
 					<img className="absolute left-0 top-0" src={defaultPorfileIcon} alt="친구 캐러셀 이미지" />
 					{(isMyProfile || isConnecting) && (
-						<ConnectionIcon className="absolute bottom-[0.5rem] left-[4.3rem] rounded-full border-[0.2rem] border-gray-bg-01" />
+						<ConnectionIcon className="absolute bottom-[0.45rem] left-[3.6rem] rounded-full border-[0.2rem] border-gray-bg-01 2xl:bottom-[0.5rem] 2xl:left-[4.3rem]" />
 					)}
 				</div>
 			</div>

--- a/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
+++ b/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
@@ -6,8 +6,8 @@ interface DateBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const ButtonDate = ({ isSelected, children, ...props }: DateBtnProps) => {
-	const commonBtnStyle = 'flex w-full h-[7.6rem] items-center justify-center text-white ';
-	const textStyle = isSelected ? 'head-bold-24' : 'subhead-reg-22';
+	const commonBtnStyle = 'flex w-full h-[5.8rem] 2xl:h-[7.6rem] items-center justify-center text-white ';
+	const textStyle = isSelected ? 'subhead-bold-20 2xl:head-bold-24' : 'subhead-med-18 2xl:subhead-reg-22';
 	const borderStyle = isSelected ? 'border-b-[0.3rem] border-mint-01' : 'border-b-[0.2rem] border-gray-02';
 
 	const groupHoverBorderStyle = isSelected ? '' : 'group-hover:border-b-[0.3rem] group-hover:border-gray-03';

--- a/src/pages/HomePage/DatePicker/DatePicker.tsx
+++ b/src/pages/HomePage/DatePicker/DatePicker.tsx
@@ -32,12 +32,13 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 	};
 
 	return (
-		<header className="mb-[2.8rem] w-full">
+		<header className="mb-[1.6rem] w-full 2xl:mb-[2.8rem]">
 			<section className="relative">
 				<Dropdown>
 					<Dropdown.Trigger>
 						<div className="mb-[0.6rem] flex items-center gap-[2rem]">
-							<h1 className="text-white title-bold-32">{currentDate.format('YYYY년 MM월')}</h1>;
+							<h1 className="text-white head-bold-28 2xl:title-bold-32">{currentDate.format('YYYY년 MM월')}</h1>
+							;
 							<ButtonArrowIcon className={'rounded-full bg-gray-bg-03 hover:bg-gray-bg-05'} />
 						</div>
 					</Dropdown.Trigger>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -170,9 +170,12 @@ const HomePage = () => {
 	};
 
 	return (
-		<AutoFixedGrid type="home" className="gap-[9.2rem] overflow-auto bg-gray-bg-01 p-[3.2rem] pt-[15.2rem]">
-			<div className="absolute left-[3.2rem] top-[5.4rem] flex items-center gap-[1.8rem]">
-				<ul className="flex gap-[1.8rem]">
+		<AutoFixedGrid
+			type="home"
+			className="gap-[9.2rem] overflow-auto bg-gray-bg-01 p-[3.2rem] pt-[13.5rem] 2xl:pt-[15.2rem]"
+		>
+			<div className="absolute left-[3.2rem] top-[4rem] flex items-center gap-[0.8rem] 2xl:top-[5.4rem] 2xl:gap-[1.8rem]">
+				<ul className="flex gap-[0.8rem] 2xl:gap-[1.8rem]">
 					<li>
 						<ButtonUserProfile isMyProfile />
 					</li>
@@ -189,7 +192,9 @@ const HomePage = () => {
 				<ButtonMoreFriends friendsCount={13} />
 			</div>
 
-			<div className={`absolute right-[4.2rem] top-[5.4rem] flex gap-[0.8rem] ${addTodayTodosOverlayStyle}`}>
+			<div
+				className={`absolute right-[4.2rem] top-[4rem] flex gap-[0.8rem] 2xl:top-[5.4rem] ${addTodayTodosOverlayStyle}`}
+			>
 				<button onClick={handleOpenFriendsModal}>
 					<FriendSettingIcon className="rounded-[1.6rem] hover:bg-gray-bg-04 active:bg-gray-bg-05" />
 				</button>
@@ -200,7 +205,7 @@ const HomePage = () => {
 
 			{/* NOTE: 1440 이하일 때는 UI가 더이상 줄어들지 않게 조정 */}
 			<AutoFixedGrid.Slot className="h-full min-h-0 min-w-[894px] max-w-[1374px]">
-				{isCategoriesDataError && <FallbackApiError resetError={() => {}} />}
+				{/* {isCategoriesDataError && <FallbackApiError resetError={() => {}} />} */}
 				<Spacer.Height as="main" className="flex flex-col gap-[1.6rem]">
 					<DatePicker
 						todayDate={todayDate}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 홈 페이지 상단 반응형 일부 수정

## 🔧 작업 내용
### 홈 페이지 상단 반응형 일부를 수정했어요
- 맥북 13인치에서 테스트해봤을 때 글자 크기와 마진이 너무 커서 , 전반적인 UI 수정이 필요해요 ㅠㅠ.. 
- 디자인 final spec 대로 하면 작은 화면에서는 ui가 너무 커보여서 임의로 일단 예시로 수정을 해놓았어요
- 대규모 수정이 필요해서 반응형 작업은 sse 연결 후 이어서 작업하려고 해요.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
> 적용 전
> <img width="1263" alt="image" src="https://github.com/user-attachments/assets/9c176bdc-cd6a-4ae8-be38-96613ce5d2e2" />




<br/>


> 적용 후 : 1512px 이하에서만 해당 스타일 적용
> <img width="1002" alt="image" src="https://github.com/user-attachments/assets/53b9c1c0-eaa8-4115-84dc-f8ea55e0e31c" />

