### PR TITLE
[ QA ] 홈페이지 상단 월과 드랍다운 화살표 사이 간격 수정합니다

### DIFF
--- a/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
+++ b/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
@@ -6,7 +6,7 @@ interface DateBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const ButtonDate = ({ isSelected, children, ...props }: DateBtnProps) => {
-	const commonBtnStyle = 'flex w-full h-[5.8rem] 2xl:h-[7.6rem] items-center justify-center text-white ';
+	const commonBtnStyle = 'flex w-full h-[7.8rem] py-[0.8rem] 2xl:h-[7.6rem] items-center justify-center text-white ';
 	const textStyle = isSelected ? 'subhead-bold-20 2xl:head-bold-24' : 'subhead-med-18 2xl:subhead-reg-22';
 	const borderStyle = isSelected ? 'border-b-[0.3rem] border-mint-01' : 'border-b-[0.2rem] border-gray-02';
 

--- a/src/pages/HomePage/DatePicker/DatePicker.tsx
+++ b/src/pages/HomePage/DatePicker/DatePicker.tsx
@@ -36,9 +36,8 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 			<section className="relative">
 				<Dropdown>
 					<Dropdown.Trigger>
-						<div className="mb-[0.6rem] flex items-center gap-[2rem]">
+						<div className="mb-[0.7rem] flex items-center gap-[2rem]">
 							<h1 className="text-white head-bold-28 2xl:title-bold-32">{currentDate.format('YYYY년 MM월')}</h1>
-							;
 							<ButtonArrowIcon className={'rounded-full bg-gray-bg-03 hover:bg-gray-bg-05'} />
 						</div>
 					</Dropdown.Trigger>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #283

## ✅ 작업 리스트

- [x] 홈페이지 상단 월과 드랍다운 화살표 사이 간격(gap) 수정
- [x] ButtonDate 높이 수정

## 🔧 작업 내용
홈페이지 상단 월과 드랍다운 화살표 사이 간격, ButtonDate 높이 피그마에 맞추어 수정하였습니다.

<img width="234" alt="스크린샷 2025-03-13 오후 6 15 39" src="https://github.com/user-attachments/assets/74a6c9f9-679e-4e34-936d-b98ae428671c" />

기존 코드에 `;`이 들어가있어서 `gap`이 `2rem`이 아닌 `4rem`이 적용되고 있었습니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
