### PR TITLE
[ QA ] 나스미디어 아이콘 favicon 주소 변경 

### DIFF
--- a/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
+++ b/src/pages/HomePage/DatePicker/ButtonDate/ButtonDate.tsx
@@ -6,7 +6,7 @@ interface DateBtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const ButtonDate = ({ isSelected, children, ...props }: DateBtnProps) => {
-	const commonBtnStyle = 'flex w-full h-[5.8rem] 2xl:h-[7.6rem] items-center justify-center text-white ';
+	const commonBtnStyle = 'flex w-full h-[7.8rem] py-[0.8rem] 2xl:h-[7.6rem] items-center justify-center text-white ';
 	const textStyle = isSelected ? 'subhead-bold-20 2xl:head-bold-24' : 'subhead-med-18 2xl:subhead-reg-22';
 	const borderStyle = isSelected ? 'border-b-[0.3rem] border-mint-01' : 'border-b-[0.2rem] border-gray-02';
 

--- a/src/pages/HomePage/DatePicker/DatePicker.tsx
+++ b/src/pages/HomePage/DatePicker/DatePicker.tsx
@@ -36,9 +36,8 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 			<section className="relative">
 				<Dropdown>
 					<Dropdown.Trigger>
-						<div className="mb-[0.6rem] flex items-center gap-[2rem]">
+						<div className="mb-[0.7rem] flex items-center gap-[2rem]">
 							<h1 className="text-white head-bold-28 2xl:title-bold-32">{currentDate.format('YYYY년 MM월')}</h1>
-							;
 							<ButtonArrowIcon className={'rounded-full bg-gray-bg-03 hover:bg-gray-bg-05'} />
 						</div>
 					</Dropdown.Trigger>

--- a/src/shared/constants/suggestedSites.ts
+++ b/src/shared/constants/suggestedSites.ts
@@ -108,7 +108,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://www.mezzomedia.co.kr/',
 		},
 		{
-			favicon: 'https://www.nasmedia.co.kr/favicon.ico',
+			favicon: 'https://www.nasmedia.co.kr/wp-content/themes/nasmedia/images/favicon/r-01.png',
 			siteName: '나스 미디어',
 			pageName: 'Nas Media',
 			siteUrl: 'https://www.nasmedia.co.kr/',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] favicon url 상수 변경

## 🔧 작업 내용

기존 나스미디어의 favicon 자원 위치가 잘못 기재돼 있어 자원 주소를 변경했습니다. 

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
<img width="583" alt="image" src="https://github.com/user-attachments/assets/9cce4428-1d55-48b3-a1df-d5c7ea1b5ee1" />
