### PR TITLE
[ QA ] 홈 카테고리 로직을 수정합니다

### DIFF
--- a/src/pages/HomePage/BoxAddCategory/BoxAddCategory.tsx
+++ b/src/pages/HomePage/BoxAddCategory/BoxAddCategory.tsx
@@ -41,6 +41,7 @@ const BoxAddCategory = forwardRef<HTMLDivElement, BoxAddCategoryProps>(function 
 						onKeyPress={handleKeydown}
 						placeholder="프로젝트 제목"
 						className="w-full bg-transparent text-white subhead-semibold-18 focus:outline-none"
+						autoFocus
 					/>
 					<div className="ml-[1rem] flex gap-[1rem]">
 						<button disabled className="rounded-full hover:bg-gray-bg-04 active:bg-gray-bg-05">

--- a/src/pages/HomePage/BoxCategory/BoxTodoInput/BoxTodoInput.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxTodoInput/BoxTodoInput.tsx
@@ -73,6 +73,7 @@ const BoxTodoInput = forwardRef<HTMLDivElement, BoxTodoInputProps>(function BoxT
 								onChange={handleInputChange}
 								onKeyPress={handleKeyPress}
 								placeholder="할 일 입력"
+								autoFocus
 							/>
 						) : (
 							<h3 className="mt-[0.42rem] text-gray-04 detail-reg-14" onDoubleClick={handleDoubleClick}>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -191,7 +191,20 @@ const HomePage = () => {
 		});
 	};
 
+	const setTodayTodoAtom = useSetAtom(todayTodoAtom);
+
 	const handleDeleteCategory = (categoryId: number) => {
+		const updatedTodayTodos = todayTodos.filter((todo) => {
+			const belongsToDeletedCategory = dailyCategoryTask.some(
+				({ category, tasks }) => category.id === categoryId && tasks.some((task) => task.id === todo.id),
+			);
+			return !belongsToDeletedCategory;
+		});
+
+		setTodayTodos(updatedTodayTodos);
+
+		setTodayTodoAtom(updatedTodayTodos);
+
 		deleteCategory({ categoryId });
 	};
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -191,8 +191,6 @@ const HomePage = () => {
 		});
 	};
 
-	const setTodayTodoAtom = useSetAtom(todayTodoAtom);
-
 	const handleDeleteCategory = (categoryId: number) => {
 		const updatedTodayTodos = todayTodos.filter((todo) => {
 			const belongsToDeletedCategory = dailyCategoryTask.some(
@@ -202,8 +200,6 @@ const HomePage = () => {
 		});
 
 		setTodayTodos(updatedTodayTodos);
-
-		setTodayTodoAtom(updatedTodayTodos);
 
 		deleteCategory({ categoryId });
 	};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 카테고리, 태스크 생성 시 텍스트필드로 포커스 안가는 문제 해결
- [x] 카테고리 삭제해도 오늘 할일에 남아있는 문제 해결

## 🔧 작업 내용
## 카테고리, 태스크 생성 시 텍스트필드로 포커스 안가는 문제 해결
`input`태그에 `autoFocus`속성 추가해주어서 간단하게 해결했습니다.

## 카테고리 삭제해도 할 일 테스크 오늘 할일에 남아있는 문제 해결(동기화)
**기존 코드**
```js
const handleDeleteCategory = (categoryId: number) => {
		deleteCategory({ categoryId });
	};
```
단순히, 카테고리 삭제시 해당 id의 카테고리만 삭제해주고 있음.

**변경 코드**
```js
const handleDeleteCategory = (categoryId: number) => {
		const updatedTodayTodos = todayTodos.filter((todo) => {
			const belongsToDeletedCategory = dailyCategoryTask.some(
				({ category, tasks }) => category.id === categoryId && tasks.some((task) => task.id === todo.id),
			);
			return !belongsToDeletedCategory;
		});

		setTodayTodos(updatedTodayTodos);

		deleteCategory({ categoryId });
	};
```
1. `todayTodos` 배열에서 삭제되는 카테고리에 속한 할 일들을 제거할 수 있도록 필터링 과정을 거쳐 `category.id`가 삭제할 `categoryId`와 일치하고, 그 안의 `tasks` 배열에 현재 `todo.id`와 같은 `task.id`가 있다면, 이 `todo`는 삭제 대상(belongsToDeletedCategory)이 됩니다.
2. 필터링된 목록으로 todayTodos 상태를 업데이트합니다.
3. 기존과 동일하게 카테고리 삭제를 진행합니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

> 카테고리 생성 시 텍스트필드로 포커스 자동으로 가도록 수정

https://github.com/user-attachments/assets/e6eb99a5-ea37-447c-bc67-782968856205



> 태스크 생성 시 텍스트필드로 포커스 자동으로 가도록 수정

https://github.com/user-attachments/assets/4bd2ec5e-dd26-4189-a259-8121e48aee6e



> 카테고리 삭제해도 할 일 테스크 오늘 할일에 남아있는 문제 해결

https://github.com/user-attachments/assets/400b19ca-25ab-4e2d-881b-9695d7761360

