### PR TITLE
[ QA ] 홈 캘린더 로직을 수정합니다

### DIFF
--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -1,6 +1,6 @@
 import { Dayjs } from 'dayjs';
 
-import { Suspense, lazy, useRef, useState } from 'react';
+import { KeyboardEvent, Suspense, lazy, useRef, useState } from 'react';
 
 import BoxTodo from '@/shared/components/BoxTodo/BoxTodo';
 import ButtonTodoToggle from '@/shared/components/ButtonTodayToggle/ButtonTodoToggle';
@@ -123,6 +123,13 @@ const BoxCategory = ({
 		});
 	};
 
+	const handleCalendarKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === 'Enter' && isCalendarOpened) {
+			handleCreatePost();
+			e.preventDefault();
+		}
+	};
+
 	return (
 		<Spacer.Height
 			as="article"
@@ -170,7 +177,16 @@ const BoxCategory = ({
 
 									{!editable && (
 										<Suspense fallback={<div>Loading...</div>}>
-											<div className="absolute left-[7.25rem] top-[9.5rem]">
+											<div
+												className="absolute left-[7.25rem] top-[9.5rem]"
+												tabIndex={0}
+												ref={(node) => {
+													if (node) {
+														node.focus();
+													}
+												}}
+												onKeyDown={handleCalendarKeyDown}
+											>
 												<Calendar
 													isPeriodOn={isPeriodOn}
 													selectedStartDate={selectedStartDate ?? defaultDate}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -107,8 +107,7 @@ const BoxCategory = ({
 
 		setName('');
 		setIsAdding(false);
-		handleStartDateInput(null);
-		handleEndDateInput(null);
+
 		handlePeriodEnd();
 	};
 

--- a/src/shared/components/Calendar/Calendar.tsx
+++ b/src/shared/components/Calendar/Calendar.tsx
@@ -1,10 +1,9 @@
 import dayjs, { Dayjs } from 'dayjs';
 
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import DatePicker from 'react-datepicker';
 
 import ButtonStatusToggle from '@/shared/components/ButtonStatusToggle/ButtonStatusToggle';
-import ButtonCalendarAddRoutine from '@/shared/components/Calendar/ButtonCalendarAddRoutine/ButtonCalendarAddRoutine';
 import HeaderCalendar from '@/shared/components/Calendar/HeaderCalendar/HeaderCalendar';
 
 import useClickOutside from '@/shared/hooks/useClickOutside';
@@ -49,7 +48,6 @@ const Calendar = ({
 	onPeriodToggle,
 	clickOutSideCallback,
 }: CalendarProps) => {
-	const [isRoutineOn, setIsRoutineOn] = useState(false);
 	const calendarRef = useRef<HTMLDivElement>(null);
 
 	useClickOutside(calendarRef, clickOutSideCallback);
@@ -83,10 +81,6 @@ const Calendar = ({
 		const [start, end] = dates;
 		onStartDateInput(start ? dayjs(start) : null);
 		onEndDateInput(end ? dayjs(end) : null);
-	};
-
-	const handleRoutineToggle = () => {
-		setIsRoutineOn((prev) => !prev);
 	};
 
 	return (
@@ -137,15 +131,6 @@ const Calendar = ({
 					<div className={`${STYLES.defaultToggle}`}>
 						<h3 className={STYLES.toggleText}>종료 날짜</h3>
 						<ButtonStatusToggle isToggleOn={isPeriodOn} onToggle={onPeriodToggle} />
-					</div>
-
-					<hr className={STYLES.divideLine} />
-					<div className="flex-col gap-[1.2rem]">
-						<div className={`${STYLES.defaultToggle}`}>
-							<h3 className={STYLES.toggleText}>루틴 생성</h3>
-							<ButtonStatusToggle isToggleOn={isRoutineOn} onToggle={handleRoutineToggle} />
-						</div>
-						{isRoutineOn && <ButtonCalendarAddRoutine />}
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 연속으로 할 일 생성 시 생성안되는 문제 해결
- [x] 종료날짜 토글 안 키고 날짜 선택할 때 아무것도 클릭안하고 엔터누르면 오늘 날짜 선택되도록 수정
- [x] 달력에서 루틴 삭제

## 🔧 작업 내용

## 연속으로 할 일 생성 시 생성안되는 문제 해결

기존 `handleCreatePost` 코드
```js
const handleCreatePost = () => {
		const dataToPost = {
			categoryId: id,
			name: name,
			startDate: format(selectedStartDate) as string,
			endDate: format(selectedEndDate),
		};
		mutate(dataToPost);

		setName('');
		setIsAdding(false);
		handleStartDateInput(null);
		handleEndDateInput(null);

		handlePeriodEnd();
	};
```

기존에는 캘린더에서 startdate와 endDate를 담어서 할 일 생성시(handleCreatePost) 명시적으로 `handleStartDateInput(null);`, `handleEndDateInput(null);` null을 할당해주는 코드가 있어서 첫번째 할 일 생성은 post요청이 잘가는데 연속으로 2번이상 할 일 생성시에는 지속적으로 startDate와 EndDate에 null이 담기는 문제가 있었음. 

변경 `handleCreatePost` 코드
```js
const handleCreatePost = () => {
		const dataToPost = {
			categoryId: id,
			name: name,
			startDate: format(selectedStartDate) as string,
			endDate: format(selectedEndDate),
		};
		mutate(dataToPost);

		setName('');
		setIsAdding(false);

		handlePeriodEnd();
	};
```
`handleStartDateInput(null);`, `handleEndDateInput(null);`코드를 삭제해주어서 간단하게 해결.


## 캘린더가 열렸을 때 'enter' 눌러도 할 일 생성 되도록 수정


<img width="376" alt="스크린샷 2025-03-15 오후 2 38 29" src="https://github.com/user-attachments/assets/a7accac5-ce6b-41b7-8d13-90b792b7a596" />

Calendar 컴포넌트를 감싸고 있는 상위 태그에
1. div가 포커스를 받을 수 있도록 tabIndex={0} 부여
2. 콜백 ref 사용:  div의 ref에 콜백 함수를 전달하여, 마운트되면 즉시 node.focus()를 호출하도록 

## 달력에서 루틴 삭제
<img width="262" alt="스크린샷 2025-03-15 오후 2 43 51" src="https://github.com/user-attachments/assets/a8b29138-64c3-43b6-a500-f7021eba12fe" />

우선 피그마 디자인을 정확하게 반영하기에는 시간이 많이 들것 같아서 우선 루틴 토글 버튼만 삭제해놓은 상태입니다


 


## 🧐 새로 알게된 점
특정 요소가 마운트될 때 자동으로 포커스하는 방법

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

> 첫번째 할 일 생성(enter), 두번째 할 일 생성(캘린더 바깥쪽 영역 클릭)
https://github.com/user-attachments/assets/bddeb1b5-c131-435c-ae49-d1fdeea00747


