### PR TITLE
[ QA ] 온보딩 페이지 타이틀 컬러 변경 기능을 추가합니다.

### DIFF
--- a/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Header/AllowedServiceGroupDetailHeader.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Header/AllowedServiceGroupDetailHeader.tsx
@@ -131,12 +131,12 @@ const AllowedServiceGroupDetailHeaderInput = ({ ...props }: AllowedServiceGroupD
 };
 
 export interface AllowedServiceGroupDetailHeaderColorButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-	hashColor: ColorPaletteType;
-	onSelectColor: (hashColor: ColorPaletteType) => void;
+	selectedColor: ColorPaletteType;
+	onSelectColor: (selectedColor: ColorPaletteType) => void;
 }
 
 const AllowedServiceGroupDetailHeaderColorButton = ({
-	hashColor,
+	selectedColor,
 	onSelectColor,
 	...props
 }: AllowedServiceGroupDetailHeaderColorButtonProps) => {
@@ -151,8 +151,8 @@ const AllowedServiceGroupDetailHeaderColorButton = ({
 		setIsPaletteOpen(false);
 	};
 
-	const handleColorButtonClick = (hashColor: ColorPaletteType) => {
-		onSelectColor(hashColor);
+	const handleColorButtonClick = (selectedColor: ColorPaletteType) => {
+		onSelectColor(selectedColor);
 		handleClosePalette();
 	};
 
@@ -160,7 +160,10 @@ const AllowedServiceGroupDetailHeaderColorButton = ({
 
 	return (
 		<div ref={paletteRef} className="relative flex items-center gap-[0.4rem]">
-			<div onClick={handleTogglePalette} className={`h-[3rem] w-[3rem] rounded-full ${COLOR_PALETTE_MAP[hashColor]}`} />
+			<div
+				onClick={handleTogglePalette}
+				className={`h-[3rem] w-[3rem] rounded-full ${COLOR_PALETTE_MAP[selectedColor]}`}
+			/>
 			<span>
 				<ButtonArrowSVG
 					onClick={handleTogglePalette}
@@ -168,15 +171,16 @@ const AllowedServiceGroupDetailHeaderColorButton = ({
 					bg={false}
 					{...props}
 				/>
-				<ColorPalette isOpen={isPaletteOpen}>
+				<ColorPalette isOpen={isPaletteOpen} className="top-[4.8rem]">
 					{Object.keys(COLOR_PALETTE_MAP).map((hashColor) => {
 						return (
 							<ColorPalette.ColorButton
 								key={hashColor}
 								onClick={() => {
-									handleColorButtonClick(hashColor as keyof typeof COLOR_PALETTE_MAP);
+									handleColorButtonClick(hashColor as ColorPaletteType);
 								}}
-								hashColor={hashColor as keyof typeof COLOR_PALETTE_MAP}
+								hashColor={hashColor as ColorPaletteType}
+								isSelected={hashColor === selectedColor}
 							/>
 						);
 					})}

--- a/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
@@ -121,10 +121,9 @@ const AllowedServiceListItem = ({
 			</Spacer.Width>
 
 			<div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
-				{allowedServiceGroupData.allowedSites &&
-					allowedServiceGroupData.allowedSites.map((siteUrl) => (
-						<img key={siteUrl} src={siteUrl} alt="favicon" className="h-[2rem] w-[2rem] rounded-full" />
-					))}
+				{allowedServiceGroupData?.favicons.map((siteUrl) => (
+					<img key={siteUrl} src={siteUrl} alt="favicon" className="h-[2rem] w-[2rem] rounded-full" />
+				))}
 				{allowedServiceGroupData?.extraCnt > 0 && (
 					<div className="body-detail-reg-12 flex h-[2rem] w-[2rem] items-center justify-center rounded-[57px] bg-date-active text-white">
 						+{allowedServiceGroupData.extraCnt}

--- a/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
@@ -10,8 +10,6 @@ import { COLOR_PALETTE_MAP } from '@/shared/constants/colorPalette';
 import MeatBallDefaultIcon from '@/shared/assets/svgs/common/ic_meatball_default.svg?react';
 import PlusIcon from '@/shared/assets/svgs/plus.svg?react';
 
-import { getServiceFavicon } from '@/pages/OnboardingPage/utils/serviceUrl';
-
 export interface AllowedService {
 	id: number;
 	allowedServiceName: string;
@@ -123,10 +121,11 @@ const AllowedServiceListItem = ({
 			</Spacer.Width>
 
 			<div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
-				{allowedServiceGroupData.allowedSites.map((siteUrl) => (
-					<img key={siteUrl} src={siteUrl} alt="favicon" className="h-[2rem] w-[2rem] rounded-full" />
-				))}
-				{allowedServiceGroupData.extraCnt > 0 && (
+				{allowedServiceGroupData.allowedSites &&
+					allowedServiceGroupData.allowedSites.map((siteUrl) => (
+						<img key={siteUrl} src={siteUrl} alt="favicon" className="h-[2rem] w-[2rem] rounded-full" />
+					))}
+				{allowedServiceGroupData?.extraCnt > 0 && (
 					<div className="body-detail-reg-12 flex h-[2rem] w-[2rem] items-center justify-center rounded-[57px] bg-date-active text-white">
 						+{allowedServiceGroupData.extraCnt}
 					</div>

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -294,7 +294,7 @@ const AllowedServicePage = () => {
 							onAddAllowedServiceGroup={handleAddAllowedServiceGroup}
 							onChangeAllowedServiceGroupName={handleChangeAllowedServiceGroupName}
 						>
-							<AllowedServiceGroupDetail.ColorButton onSelectColor={handleSelectColor} hashColor={selectedColor} />
+							<AllowedServiceGroupDetail.ColorButton onSelectColor={handleSelectColor} selectedColor={selectedColor} />
 							<AllowedServiceGroupDetail.Input
 								value={titleInput}
 								onChange={handleChangeTitleInput}

--- a/src/pages/OnboardingPage/StepService/AllowedServices/AllowedServices.tsx
+++ b/src/pages/OnboardingPage/StepService/AllowedServices/AllowedServices.tsx
@@ -1,12 +1,17 @@
-import { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
+import { ButtonHTMLAttributes, InputHTMLAttributes, KeyboardEvent, ReactNode, useRef, useState } from 'react';
 
 import HomeLargeBtn from '@/shared/components/ButtonHomeLarge/ButtonHomeLarge';
+import ColorPalette from '@/shared/components/ColorPallete/ColorPallete';
 import Spacer from '@/shared/components/Spacer/Spacer';
 
+import useClickOutside from '@/shared/hooks/useClickOutside';
+
+import { ColorPaletteType } from '@/shared/types/allowedService';
 import { AllowedSiteType } from '@/shared/types/allowedSites';
 import { HomeLargeBtnVariant } from '@/shared/types/global';
 
-import ColorIcon from '@/shared/assets/svgs/ic_color.svg?react';
+import { COLOR_PALETTE_MAP } from '@/shared/constants/colorPalette';
+
 import MinusIcon from '@/shared/assets/svgs/ic_minus.svg?react';
 import PencilIcon from '@/shared/assets/svgs/ic_pencil.svg?react';
 
@@ -26,55 +31,111 @@ interface AllowedServiceHeaderProps {
 	children: ReactNode;
 }
 
-const AllowedServiceHeader = () => {
+const AllowedServiceHeader = ({ children }: AllowedServiceHeaderProps) => {
+	return <div className="flex items-center">{children}</div>;
+};
+
+interface AllowedServiceHeaderColorButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	selectedColor: ColorPaletteType;
+	onSelectColor: (hashColor: ColorPaletteType) => void;
+}
+
+const AllowedServiceHeaderColorButton = ({
+	selectedColor,
+	onSelectColor,
+	...props
+}: AllowedServiceHeaderColorButtonProps) => {
+	const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+	const paletteRef = useRef<HTMLDivElement>(null);
+
+	const handleTogglePalette = () => {
+		setIsPaletteOpen((prev) => !prev);
+	};
+
+	const handleClosePalette = () => {
+		setIsPaletteOpen(false);
+	};
+
+	const handleColorButtonClick = (hashColor: ColorPaletteType) => {
+		onSelectColor(hashColor);
+	};
+
+	useClickOutside(paletteRef, handleClosePalette);
+
 	return (
-		<div className="flex items-center">
-			<button>
-				<ColorIcon />
+		<div ref={paletteRef} className="relative flex h-full items-center">
+			<button onClick={handleTogglePalette} {...props}>
+				<div className={`h-[2.2rem] w-[2.2rem] rounded-full ${COLOR_PALETTE_MAP[selectedColor]}`} />
 			</button>
-			<h2 className="ml-[1rem] text-white head-bold-24">허용서비스 리스트 1</h2>
-			<button className="ml-[1.7rem]">
-				<PencilIcon />
-			</button>
+			<ColorPalette isOpen={isPaletteOpen} className={'top-[3.6rem]'}>
+				{Object.keys(COLOR_PALETTE_MAP).map((hashColor) => {
+					return (
+						<ColorPalette.ColorButton
+							key={hashColor}
+							onClick={() => {
+								handleColorButtonClick(hashColor as ColorPaletteType);
+							}}
+							hashColor={hashColor as ColorPaletteType}
+							isSelected={selectedColor === hashColor}
+						/>
+					);
+				})}
+			</ColorPalette>
 		</div>
 	);
 };
 
-const AllowedServiceHeaderColorButton = () => {
-	return (
-		<button>
-			<ColorIcon />
-		</button>
-	);
-};
-
 interface AllowedServiceHeaderInput extends InputHTMLAttributes<HTMLInputElement> {
-	onChangeEditing: (status: boolean) => void;
-	isEditing: boolean;
+	onInitCategoryNameInput: () => void;
 }
 
-const AllowedServiceHeaderInput = ({ isEditing, onChangeEditing, ...props }: AllowedServiceHeaderInput) => {
+const AllowedServiceHeaderInput = ({ onInitCategoryNameInput, ...props }: AllowedServiceHeaderInput) => {
+	const [isEditing, setIsEditing] = useState(false);
+	const divRef = useRef(null);
+
 	const handleEnableEditing = () => {
-		onChangeEditing(true);
+		setIsEditing(true);
 	};
 
 	const handleDisableEditing = () => {
-		onChangeEditing(false);
+		if (typeof props.value === 'string' && props.value.length === 0) {
+			onInitCategoryNameInput();
+		}
+
+		setIsEditing(false);
 	};
 
+	const handleKeydown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			handleDisableEditing();
+		}
+	};
+
+	useClickOutside(divRef, handleDisableEditing);
+
 	return (
-		<>
+		<div ref={divRef} className="flex w-full items-center">
 			{isEditing ? (
 				<input
 					{...props}
-					className="placeholder-text-gray-03 ml-[1rem] w-full bg-transparent text-white head-bold-24 focus:outline-none"
+					onKeyPress={handleKeydown}
+					autoFocus
+					className={`placeholder-text-gray-03 ml-[1rem] max-w-[calc(36.4rem-4.7rem-3.2rem)] bg-transparent text-white head-bold-24 focus:outline-none`}
 				/>
 			) : (
-				<h1 onDoubleClick={handleEnableEditing} className="ml-[1rem] w-full bg-transparent text-white head-bold-24">
-					허용서비스 리스트 1
-				</h1>
+				<>
+					<h1
+						onClick={handleEnableEditing}
+						className="ml-[1rem] max-w-[calc(36.4rem-4.7rem-3.2rem)] truncate bg-transparent text-white head-bold-24"
+					>
+						{props.value}
+					</h1>
+					<button type="button" onClick={handleEnableEditing} className="ml-[1.7rem]">
+						<PencilIcon />
+					</button>
+				</>
 			)}
-		</>
+		</div>
 	);
 };
 
@@ -122,6 +183,8 @@ const AllowedServiceBottomButton = (props: ButtonHTMLAttributes<HTMLButtonElemen
 
 const AllowedService = Object.assign(AllowedServicesRoot, {
 	Header: AllowedServiceHeader,
+	HeaderInput: AllowedServiceHeaderInput,
+	HeaderColorButton: AllowedServiceHeaderColorButton,
 	List: AllowedServiceList,
 	Item: AllowedServiceItem,
 	BottomButton: AllowedServiceBottomButton,

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -110,8 +110,8 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 				{
 					allowedSites: selectedServices,
 					interestArea: selectedField,
-					name: '허용 서비스 리스트 1',
-					colorCode: '#868C93',
+					name: categoryNameInput,
+					colorCode: selectedColor,
 				},
 				{
 					onSuccess: () => {

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -7,6 +7,7 @@ import TextField from '@/shared/components/TextField/TextField';
 
 import { isUrlValid } from '@/shared/utils/validation';
 
+import { ColorPaletteType } from '@/shared/types/allowedService';
 import { AllowedSiteType, AllowedSitesType } from '@/shared/types/allowedSites';
 import type { FieldType } from '@/shared/types/fileds';
 
@@ -15,7 +16,6 @@ import { SUGGESTED_STIES } from '@/shared/constants/suggestedSites';
 
 import BackIcon from '@/shared/assets/svgs/ic_back_btn.svg?react';
 
-import { getUrlInfo } from '@/shared/apisV2/common/common.api';
 import { useGetUrlInfo } from '@/shared/apisV2/common/common.mutations';
 import { usePostInterestArea } from '@/shared/apisV2/onboarding/onboarding.mutations';
 
@@ -33,12 +33,12 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	const [inputUrl, setInputUrl] = useState('');
 	const [selectedServices, setSelectedServices] = useState<AllowedSitesType>([]);
 	const [inputSuccess, setInputSuccess] = useState(false);
-	const [categoryInput, setCategoryInput] = useState('허용서비스 리스트 1');
-	const [isEditingCategory, setIsEditingCategory] = useState(false);
+	const [categoryNameInput, setCategoryNameInput] = useState('허용서비스 리스트 1');
+	const [selectedColor, setSelectedColor] = useState<ColorPaletteType>('#868C93');
 
 	const navigate = useNavigate();
 
-	const { mutateAsync: getUrlInfo, reset: resetGetUrlInfo, isError, error } = useGetUrlInfo();
+	const { mutateAsync: getUrlInfo, reset: resetGetUrlInfo, isError, error, isPending } = useGetUrlInfo();
 	const { mutate: postInterestArea } = usePostInterestArea();
 
 	const isSelectedUrl = (siteUrl: string) => {
@@ -93,13 +93,13 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 		setInputUrl('');
 	};
 
-	// const handleChangeCategoryInput = (e: ChangeEvent<HTMLInputElement>) => {
-	// 	setCategoryInput(e.target.value);
-	// };
+	const handleChangeCategoryNameInput = (e: ChangeEvent<HTMLInputElement>) => {
+		setCategoryNameInput(e.target.value);
+	};
 
-	// const handleChangeEditingCategoryStatus = (status: boolean) => {
-	// 	setIsEditingCategory(status);
-	// };
+	const handleInitCategoryNameInput = () => {
+		setCategoryNameInput('허용 서비스 리스트 1');
+	};
 
 	const handleComplete = () => {
 		if (!selectedField) {
@@ -121,7 +121,6 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 			);
 		}
 	};
-	console.log(selectedServices);
 
 	return (
 		<AutoFixedGrid type="onboarding" className="relative gap-[2rem] bg-gray-bg-01 px-[6rem] pb-[5rem] pt-[11rem]">
@@ -170,7 +169,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 					>
 						<TextField.ClearButton onClick={handleClickClearButton} />
 						<TextField.ConfirmButton
-							disabled={inputUrl.length === 0}
+							disabled={inputUrl.length === 0 || isPending}
 							onClick={() => handleAddSelectedService(inputUrl)}
 						>
 							등록하기
@@ -181,7 +180,14 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 
 			<AutoFixedGrid.Slot className="h-full min-h-0">
 				<AllowedService>
-					<AllowedService.Header />
+					<AllowedService.Header>
+						<AllowedService.HeaderColorButton selectedColor={selectedColor} onSelectColor={setSelectedColor} />
+						<AllowedService.HeaderInput
+							value={categoryNameInput}
+							onChange={handleChangeCategoryNameInput}
+							onInitCategoryNameInput={handleInitCategoryNameInput}
+						/>
+					</AllowedService.Header>
 					<AllowedService.List>
 						{selectedServices.map((service) => (
 							<AllowedService.Item

--- a/src/shared/assets/svgs/ic_color.svg
+++ b/src/shared/assets/svgs/ic_color.svg
@@ -1,3 +1,0 @@
-<svg width="22" height="23" viewBox="0 0 22 23" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="11" cy="11.5" r="11" fill="#868C93"/>
-</svg>

--- a/src/shared/components/ColorPallete/ColorPallete.tsx
+++ b/src/shared/components/ColorPallete/ColorPallete.tsx
@@ -4,11 +4,12 @@ import { COLOR_PALETTE_MAP } from '@/shared/constants/colorPalette';
 
 interface ColorPaletteRootProps {
 	isOpen: boolean;
+	className?: string;
 	children: ReactNode;
 }
 
 const ColorPaletteRoot = forwardRef<HTMLDivElement, ColorPaletteRootProps>(function ColorPaletteRoot(
-	{ isOpen, children },
+	{ isOpen, className, children },
 	ref,
 ) {
 	if (!isOpen) return null;
@@ -16,7 +17,7 @@ const ColorPaletteRoot = forwardRef<HTMLDivElement, ColorPaletteRootProps>(funct
 	return (
 		<div
 			ref={ref}
-			className="absolute left-0 top-[4.8rem] z-50 grid h-[11.6rem] w-[32rem] grid-cols-6 grid-rows-2 gap-x-[2rem] gap-y-[1.2rem] rounded-[8px] bg-gray-bg-04 px-[2rem] py-[2.2rem]"
+			className={`absolute left-0 z-50 grid h-[11.6rem] w-[32rem] grid-cols-6 grid-rows-2 gap-x-[2rem] gap-y-[1.2rem] rounded-[8px] bg-gray-bg-04 px-[2rem] py-[2.2rem] ${className}`}
 		>
 			{children}
 		</div>
@@ -25,11 +26,15 @@ const ColorPaletteRoot = forwardRef<HTMLDivElement, ColorPaletteRootProps>(funct
 
 interface ColorPaletteColorButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	hashColor: keyof typeof COLOR_PALETTE_MAP;
+	isSelected?: boolean;
 }
 
-const ColorPaletteColorButton = ({ hashColor, ...props }: ColorPaletteColorButtonProps) => {
+const ColorPaletteColorButton = ({ hashColor, isSelected, ...props }: ColorPaletteColorButtonProps) => {
 	return (
-		<button {...props} className={`h-[3rem] w-[3rem] flex-shrink-0 rounded-full ${COLOR_PALETTE_MAP[hashColor]}`} />
+		<button
+			{...props}
+			className={`h-[3rem] w-[3rem] flex-shrink-0 rounded-full ${isSelected && 'border-[2px] border-white'} ${COLOR_PALETTE_MAP[hashColor]}`}
+		/>
 	);
 };
 

--- a/src/shared/types/api/allowedService.ts
+++ b/src/shared/types/api/allowedService.ts
@@ -16,7 +16,7 @@ export interface GetAllowedServiceListRes {
 		id: number;
 		name: string;
 		colorCode: ColorPaletteType;
-		allowedSites: string[];
+		favicons: string[];
 		extraCnt: 0;
 	}[];
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 온보딩 페이지 타이틀 컬러 변경 기능을 추가합니다.
- [x] 컬러팔레트 선택된 컬러 보더 추가하는 기능 추가
- [x] AllowedServicePage api 응답 타입이 잘못되어 있어, 최신 명세에 맞게 수정

## 🔧 작업 내용
- 온보딩 페이지 타이틀 컬러 변경 기능을 추가했어요
  - 이 부분은 최근에 api가 변경되었는데 연동이 안되어있어서, selectedColor와 categoryNameInput 상태를 추가해서 구현했습니다.
- 컬러팔레트 선택된 컬러 보더 추가하는 기능 추가
  - 컬러 팔레트에 isSelected 프롭을 추가하여 선택된 컬러 팔레트의 경우 border 색상이 추가 될 수 있게 했어요.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/6417d1eb-338c-4f6b-b28b-91dc2dd0e9ec

