### PR TITLE
[ QA ] 타이머 페이지 선택된 할일이 첫번째 할일로 초기화 되는 오류를 수정합니다.

### DIFF
--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -56,6 +56,7 @@ const TimerPage = () => {
 	const { ongoingTodos, completedTodos } = splitTasksByCompletion(todos);
 	const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
 	const [selectedTodoData, setSelectedTodoData] = useState<TimerTodoType | undefined>(undefined);
+	const [isInitialRender, setIsInitialRender] = useState(false);
 
 	const [registeredNames, setRegisteredNames] = useState<string[]>([]);
 	const [allowedSitesUrl, setAllowedSitesUrl] = useState<string[]>([]);
@@ -120,9 +121,10 @@ const TimerPage = () => {
 	};
 
 	useEffect(() => {
-		if (todosData && todosData.data.task.length > 0) {
+		if (todosData && todosData.data.task.length > 0 && isInitialRender) {
 			const selectedId = todosData.data.task[0].id;
 			setSelectedTodoId(selectedId);
+			setIsInitialRender(false);
 		}
 	}, [todosData]);
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 타이머 페이지 선택된 할일이 첫번째 할일로 초기화 되는 오류 수정

## 🔧 작업 내용

초기에 useEffect를 통해서 데이터를 받아온 뒤 첫번째 할일을 선택해주고 있었습니다.
useEffect의 의존성 배열에 데이터를 넣어두어 데이터가 업데이트 될 때 마다 첫번째 할일로 초기화가 되는 문제가 발생했어요
그래서 isInitialRender라는 상태 플래그를 만들어 해결했습니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/18105979-d66b-4bc8-8528-f4a9e1ae4d6d


