### PR TITLE
[ QA ] 홈 페이지 QA사항 반영합니다.

### DIFF
--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -36,6 +36,7 @@ interface BoxCategoryProps {
 	onDeleteCategory: (categoryId: number) => void;
 	onModifyCategory: (categoryId: number, newName: string) => void;
 	isSelectedTodoExist?: boolean;
+	selectedDate: Dayjs;
 }
 
 const format = (date: Dayjs | null) => {
@@ -58,6 +59,7 @@ const BoxCategory = ({
 	onDeleteCategory,
 	onModifyCategory,
 	isSelectedTodoExist,
+	selectedDate,
 }: BoxCategoryProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
 	const [ongoingTodoToggle, setOngoingTodoToggle] = useState(true);
@@ -90,7 +92,6 @@ const BoxCategory = ({
 
 	const {
 		isPeriodOn,
-		selectedStartDate,
 		selectedEndDate,
 		isCalendarOpened,
 		defaultDate,
@@ -104,13 +105,14 @@ const BoxCategory = ({
 		const dataToPost = {
 			categoryId: id,
 			name: name,
-			startDate: format(selectedStartDate) as string,
+			startDate: format(selectedDate) as string,
 			endDate: format(selectedEndDate),
 		};
 		mutate(dataToPost);
 
 		setName('');
 		setIsAdding(false);
+		handleEndDateInput(null);
 
 		handlePeriodEnd();
 	};
@@ -205,7 +207,7 @@ const BoxCategory = ({
 										onEditComplete={handleEditComplete}
 										name={name}
 										onInputChange={handleInputChange}
-										selectedStartDate={selectedStartDate}
+										selectedStartDate={selectedDate}
 										selectedEndDate={selectedEndDate}
 									/>
 
@@ -223,7 +225,7 @@ const BoxCategory = ({
 											>
 												<Calendar
 													isPeriodOn={isPeriodOn}
-													selectedStartDate={selectedStartDate ?? defaultDate}
+													selectedStartDate={selectedDate ?? defaultDate}
 													selectedEndDate={selectedEndDate ?? null}
 													onStartDateInput={handleStartDateInput}
 													onEndDateInput={handleEndDateInput}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -70,6 +70,8 @@ const BoxCategory = ({
 
 	const handleCalendarToggle = () => {
 		setIsCalendarOpen((prev) => !prev);
+		handleEndDateInput(null);
+		handlePeriodEnd();
 	};
 
 	const handleOngoingTodoToggle = () => {

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -204,7 +204,10 @@ const BoxCategory = ({
 									<BoxTodoInput
 										ref={todoRef}
 										editable={editable}
-										onEditComplete={handleEditComplete}
+										onEditComplete={() => {
+											handleEditComplete();
+											handleCreatePost();
+										}}
 										name={name}
 										onInputChange={handleInputChange}
 										selectedStartDate={selectedDate}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -280,7 +280,6 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
-										handleCalendarToggle={handleCalendarToggle}
 									/>
 								);
 							})}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -167,7 +167,9 @@ const BoxCategory = ({
 						onKeyDown={handleKeyDown}
 					/>
 				) : (
-					<h2 className="text-white subhead-semibold-18">{title}</h2>
+					<h2 className="text-white subhead-semibold-18" onClick={handleStartEditing}>
+						{title}
+					</h2>
 				)}
 				<div className="flex items-center gap-[1rem]">
 					<button

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -66,6 +66,11 @@ const BoxCategory = ({
 	const [completedTodoToggle, setCompletedTodoToggle] = useState(false);
 	const [isCategoryEditing, setIsCategoryEditing] = useState(false);
 	const [editedCategoryName, setEditedCategoryName] = useState(title);
+	const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+
+	const handleCalendarToggle = () => {
+		setIsCalendarOpen((prev) => !prev);
+	};
 
 	const handleOngoingTodoToggle = () => {
 		setOngoingTodoToggle((prev) => !prev);
@@ -199,47 +204,45 @@ const BoxCategory = ({
 				<Spacer.Height className="relative flex">
 					<Spacer.Height className="flex flex-col overflow-y-auto">
 						<ButtonTodoToggle isCompleted onClick={handleOngoingTodoToggle} isToggled={ongoingTodoToggle}>
-							{isAdding && (
-								<>
-									<BoxTodoInput
-										ref={todoRef}
-										editable={editable}
-										onEditComplete={() => {
-											handleEditComplete();
-											handleCreatePost();
-										}}
-										name={name}
-										onInputChange={handleInputChange}
-										selectedStartDate={selectedDate}
-										selectedEndDate={selectedEndDate}
-									/>
+							{isAdding && !isCalendarOpen && (
+								<BoxTodoInput
+									ref={todoRef}
+									editable={editable}
+									onEditComplete={() => {
+										handleEditComplete();
+										handleCreatePost();
+									}}
+									name={name}
+									onInputChange={handleInputChange}
+									selectedStartDate={selectedDate}
+									selectedEndDate={selectedEndDate}
+								/>
+							)}
 
-									{!editable && (
-										<Suspense fallback={<div>Loading...</div>}>
-											<div
-												className="absolute left-[7.25rem] top-[9.5rem]"
-												tabIndex={0}
-												ref={(node) => {
-													if (node) {
-														node.focus();
-													}
-												}}
-												onKeyDown={handleCalendarKeyDown}
-											>
-												<Calendar
-													isPeriodOn={isPeriodOn}
-													selectedStartDate={selectedDate ?? defaultDate}
-													selectedEndDate={selectedEndDate ?? null}
-													onStartDateInput={handleStartDateInput}
-													onEndDateInput={handleEndDateInput}
-													isCalendarOpened={isCalendarOpened}
-													onPeriodToggle={handlePeriodToggle}
-													clickOutSideCallback={handleCreatePost}
-												/>
-											</div>
-										</Suspense>
-									)}
-								</>
+							{isCalendarOpen && (
+								<Suspense fallback={<div>Loading...</div>}>
+									<div
+										className="absolute left-[7.25rem] top-[9.5rem]"
+										tabIndex={0}
+										ref={(node) => {
+											if (node) {
+												node.focus();
+											}
+										}}
+										onKeyDown={handleCalendarKeyDown}
+									>
+										<Calendar
+											isPeriodOn={isPeriodOn}
+											selectedStartDate={selectedDate ?? defaultDate}
+											selectedEndDate={selectedEndDate ?? null}
+											onStartDateInput={handleStartDateInput}
+											onEndDateInput={handleEndDateInput}
+											isCalendarOpened={isCalendarOpened}
+											onPeriodToggle={handlePeriodToggle}
+											clickOutSideCallback={handleCalendarToggle}
+										/>
+									</div>
+								</Suspense>
 							)}
 
 							{ongoingTodos.map(({ id, name, startDate, endDate, elapsedTime }) => {
@@ -250,9 +253,7 @@ const BoxCategory = ({
 									endDate,
 									elapsedTime,
 								};
-
 								const selectedNumber = getSelectedNumber(id);
-
 								return (
 									<BoxTodo
 										id={id}
@@ -277,6 +278,7 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
+										handleCalendarToggle={handleCalendarToggle}
 									/>
 								);
 							})}
@@ -299,6 +301,7 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
+										handleCalendarToggle={handleCalendarToggle}
 									/>
 								))}
 							</ButtonTodoToggle>

--- a/src/pages/HomePage/DatePicker/DatePicker.tsx
+++ b/src/pages/HomePage/DatePicker/DatePicker.tsx
@@ -21,14 +21,16 @@ interface DatePickerProps {
 }
 
 const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePickerProps) => {
-	const { currentDate, weekDates, handleNextWeek, handlePreviousWeek, handleToday, handleYearMonthClick } =
-		useDatePicker(todayDate);
+	const { weekDates, handleNextWeek, handlePreviousWeek, handleToday, handleYearMonthClick } = useDatePicker({
+		todayDate,
+		selectedDate,
+		onSelectedDateChange,
+	});
 
 	const homeDropdownData = getHomeDropdownData(todayDate);
 
 	const handleClickTodayBtn = () => {
 		handleToday();
-		onSelectedDateChange(todayDate);
 	};
 
 	return (
@@ -37,8 +39,9 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 				<Dropdown>
 					<Dropdown.Trigger>
 						<div className="mb-[0.7rem] flex items-center gap-[2rem]">
-							<h1 className="text-white head-bold-28 2xl:title-bold-32">{currentDate.format('YYYY년 MM월')}</h1>
-							<ButtonArrowIcon className={'rounded-full bg-gray-bg-03 hover:bg-gray-bg-05'} />
+							{/* selectedDate를 사용하여 월을 표시 */}
+							<h1 className="text-white head-bold-28 2xl:title-bold-32">{selectedDate.format('YYYY년 MM월')}</h1>
+							<ButtonArrowIcon className="rounded-full bg-gray-bg-03 hover:bg-gray-bg-05" />
 						</div>
 					</Dropdown.Trigger>
 
@@ -47,18 +50,16 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 						boxShadow="shadow-[0_4px_4.8px_0_rgba(0,0,0,0.25)]"
 						className="top-[4.4rem]"
 					>
-						{homeDropdownData.map((item) => {
-							return (
-								<li
-									key={item.format('YYYY년 MM월')}
-									className="flex h-[4.6rem] w-[22.5rem] flex-row items-center justify-center border-none bg-mint-01"
-								>
-									<ButtonDropdownOptions onClick={() => handleYearMonthClick(item)}>
-										{item.format('YYYY년 MM월')}
-									</ButtonDropdownOptions>
-								</li>
-							);
-						})}
+						{homeDropdownData.map((item) => (
+							<li
+								key={item.format('YYYY년 MM월')}
+								className="flex h-[4.6rem] w-[22.5rem] items-center justify-center border-none bg-mint-01"
+							>
+								<ButtonDropdownOptions onClick={() => handleYearMonthClick(item)}>
+									{item.format('YYYY년 MM월')}
+								</ButtonDropdownOptions>
+							</li>
+						))}
 					</Dropdown.Content>
 				</Dropdown>
 			</section>
@@ -72,10 +73,9 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 
 							return (
 								<li key={day}>
-									<DateBtn
-										isSelected={isSelected}
-										onClick={() => onSelectedDateChange(date)}
-									>{`${formattedDate} ${day}`}</DateBtn>
+									<DateBtn isSelected={isSelected} onClick={() => onSelectedDateChange(date)}>
+										{`${formattedDate} ${day}`}
+									</DateBtn>
 								</li>
 							);
 						})}

--- a/src/pages/HomePage/DatePicker/DatePicker.tsx
+++ b/src/pages/HomePage/DatePicker/DatePicker.tsx
@@ -39,7 +39,6 @@ const DatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: DatePicke
 				<Dropdown>
 					<Dropdown.Trigger>
 						<div className="mb-[0.7rem] flex items-center gap-[2rem]">
-							{/* selectedDate를 사용하여 월을 표시 */}
 							<h1 className="text-white head-bold-28 2xl:title-bold-32">{selectedDate.format('YYYY년 MM월')}</h1>
 							<ButtonArrowIcon className="rounded-full bg-gray-bg-03 hover:bg-gray-bg-05" />
 						</div>

--- a/src/pages/HomePage/DatePicker/hooks/useDatePicker.ts
+++ b/src/pages/HomePage/DatePicker/hooks/useDatePicker.ts
@@ -1,39 +1,37 @@
 import { Dayjs } from 'dayjs';
 
-import { useState } from 'react';
-
 import { getWeekDates } from '@/shared/utils/date';
 
-export const useDatePicker = (todayDate: Dayjs) => {
-	const [currentDate, setCurrentDate] = useState(todayDate);
+interface UseDatePickerProps {
+	todayDate: Dayjs;
+	selectedDate: Dayjs;
+	onSelectedDateChange: (date: Dayjs) => void;
+}
 
-	const weekDates = getWeekDates(currentDate);
+export const useDatePicker = ({ todayDate, selectedDate, onSelectedDateChange }: UseDatePickerProps) => {
+	const weekDates = getWeekDates(selectedDate);
 
 	const handleNextWeek = () => {
-		const nextWeek = currentDate.add(1, 'week');
-		setCurrentDate(nextWeek);
+		onSelectedDateChange(selectedDate.add(1, 'week'));
 	};
 
 	const handlePreviousWeek = () => {
-		const previousWeek = currentDate.subtract(1, 'week');
-		setCurrentDate(previousWeek);
+		onSelectedDateChange(selectedDate.subtract(1, 'week'));
 	};
 
 	const handleToday = () => {
-		setCurrentDate(todayDate);
+		onSelectedDateChange(todayDate);
 	};
 
 	const handleYearMonthClick = (yearMonthDate: Dayjs) => {
 		if (yearMonthDate.isSame(todayDate, 'month')) {
-			setCurrentDate(todayDate);
+			onSelectedDateChange(todayDate);
 		} else {
-			setCurrentDate(yearMonthDate);
+			onSelectedDateChange(yearMonthDate);
 		}
 	};
 
 	return {
-		todayDate,
-		currentDate,
 		weekDates,
 		handleNextWeek,
 		handlePreviousWeek,

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -331,6 +331,7 @@ const HomePage = () => {
 												onDeleteCategory={handleDeleteCategory}
 												onModifyCategory={handleModifyCategory}
 												isSelectedTodoExist={todayTodos.length > 0}
+												selectedDate={selectedDate}
 											/>
 										);
 									})}

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -30,7 +30,7 @@ interface BoxTodoProps {
 	addingComplete?: boolean;
 	timerIncreasedTime?: number;
 	isSelectedTodoExist?: boolean;
-	handleCalendarToggle: () => void;
+	handleCalendarToggle?: () => void;
 }
 const BoxTodo = ({
 	id,

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -30,6 +30,7 @@ interface BoxTodoProps {
 	addingComplete?: boolean;
 	timerIncreasedTime?: number;
 	isSelectedTodoExist?: boolean;
+	handleCalendarToggle: () => void;
 }
 const BoxTodo = ({
 	id,
@@ -47,6 +48,7 @@ const BoxTodo = ({
 	addingComplete,
 	timerIncreasedTime,
 	isSelectedTodoExist,
+	handleCalendarToggle,
 }: BoxTodoProps) => {
 	const { mutate: deleteTask } = useDeleteTask();
 
@@ -118,7 +120,7 @@ const BoxTodo = ({
 					)}
 				</div>
 				<div className="ml-[0.8rem] mt-[0.7rem] flex flex-col gap-[0.2rem]">
-					<button className="flex items-center gap-[0.6rem]">
+					<button className="flex items-center gap-[0.6rem]" onClick={handleCalendarToggle}>
 						<ButtonCalendarIcon />
 						<p className="mt-[0.3rem] text-gray-04 detail-reg-12">{duration}</p>
 					</button>

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -95,11 +95,7 @@ const BoxTodo = ({
 						<button onClick={onToggleComplete} className={disableBtnStyle}>
 							{CheckBoxIcon}
 						</button>
-						<h3
-							className={`mt-[0.42rem] text-white body-semibold-16 ${nameStyle} overflow-hidden text-ellipsis whitespace-nowrap`}
-						>
-							{name}
-						</h3>
+						<h3 className={`mt-[0.42rem] text-white body-semibold-16 ${nameStyle} truncate`}>{name}</h3>
 					</div>
 					{!isSelectedTodoExist && !addingComplete && (
 						<Dropdown>

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -89,11 +89,15 @@ const BoxTodo = ({
 		>
 			<div className="flex flex-col justify-center">
 				<div className="flex items-center justify-between">
-					<div className="flex items-center gap-[0.6rem]">
+					<div className="flex w-[22.2rem] items-center gap-[0.6rem]">
 						<button onClick={onToggleComplete} className={disableBtnStyle}>
 							{CheckBoxIcon}
 						</button>
-						<h3 className={`+ mt-[0.42rem] text-white body-semibold-16 ${nameStyle}`}>{name}</h3>
+						<h3
+							className={`mt-[0.42rem] text-white body-semibold-16 ${nameStyle} overflow-hidden text-ellipsis whitespace-nowrap`}
+						>
+							{name}
+						</h3>
 					</div>
 					{!isSelectedTodoExist && !addingComplete && (
 						<Dropdown>

--- a/src/shared/components/ButtonTodayToggle/ButtonTodoToggle.tsx
+++ b/src/shared/components/ButtonTodayToggle/ButtonTodoToggle.tsx
@@ -9,7 +9,7 @@ interface ButtonTodoToggle extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const ButtonTodoToggle = ({ children, isCompleted = false, isToggled, ...props }: ButtonTodoToggle) => {
 	const title = isCompleted ? '할 일 목록' : '완료된 일';
-	const ToggleIcon = isToggled ? <TodoToggleIcon className="rotate-180" /> : <TodoToggleIcon />;
+	const ToggleIcon = isToggled ? <TodoToggleIcon /> : <TodoToggleIcon className="rotate-180" />;
 
 	return (
 		<>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,7 @@ export default {
 					'@apply text-[1.8rem] font-medium leading-120': '',
 				},
 				'.body-semibold-16': {
-					'@apply text-[1.6rem] font-semibold leading-120': '',
+					'@apply text-[1.6rem] font-semibold leading-140': '',
 				},
 				'.body-semibold-16-done': {
 					'@apply text-[1.6rem] font-semibold leading-140 line-through': '',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 날짜 캐러셀(DatePicker) 왼쪽, 오른쪽 버튼 클릭시 selectedDate도 -7일, +7일 되어야 함
- [x] 할 일 카드 할 일 명 최대길이 침범시 ...으로 표시되도록 수정
- [x] 할일 목록/완료한일 목록 토글 방향 위쪽에서 아래쪽으로 수정
- [x] 카테고리 이름 클릭시 카테고리 수정 가능하게 하기
- [x] 할 일 카드 생성시 디폴트로 날짜 캐러셀의 날짜로 할 일 카드 생성되기(캘린더 open되면 안됨) 
- [x] 할 일 카드의 날짜 텍스트 클릭했을 때 캘린더 열리기
- [x] 할 일 카드 연속 생성시 캘린더의 선택된 날짜 리셋 시켜주기



## 🔧 작업 내용

## 날짜 캐러셀(DatePicker) 왼쪽, 오른쪽 버튼 클릭시 selectedDate도 -7일, +7일되도록 수정

`useDatePicker`훅에서 별도로 관리되고 있던 `const [currentDate, setCurrentDate] = useState(todayDate);` 현재 날짜를 관리하는 상태를 삭제해주었습니다. 그리고, 최상단(HomePage.tsx)에서 관리하고 있는 `selectedDate` 상태와 동기화 될 수 있도록 하여 왼쪽, 오른쪽 버튼 클릭시 `selectedDate`도 -7일, +7일될 수 있도록 하였습니다.

**기존 handleNextWeek 코드**
```js
const handleNextWeek = () => {
 		const nextWeek = currentDate.add(1, 'week');
 		setCurrentDate(nextWeek);
 	};
```

**수정된 handleNextWeek 코드**
```js
const handleNextWeek = () => {
 		onSelectedDateChange(selectedDate.add(1, 'week'));
 	};
```

## 할 일 카드 할 일 명 최대길이 침범시 ...으로 표시되도록 수정
해당 부분은 기획, 디자인과 더 논의가 필요한 부분 같습니다.
처음에는 `할 일 명`의 길이가 할 일 카드의 width값을 넘으면 자동으로 줄바꿈이 생기게되었는데, 첨부한 사진과 같이 할일카드의 영역을 벗어나는 문제가 있었습니다. 
<img width="338" alt="KakaoTalk_Photo_2025-03-19-17-13-47" src="https://github.com/user-attachments/assets/30546f3c-9c09-4b34-ab01-5e823b333d46" />
이를 해결하기위해서 `할 일 명`에 맞추어 자동으로 할 일 카드의 height도 증가하게 했습니다. 그러나, 2줄이상 넘어가게 되면 반응형이 적용되어있어서 그런지 맥북 14인치 기준 해상도 100%였을 때 할 일 카드의 height를 여전히 침범하는 문제가 생겼습니다. 캡처해두었으면 이해하기 좋았을텐데 아쉽네요. 그래서 현재는 한줄이상 `할 일 명`을 지정하게 되면 `...`으로 대체하도록 수정해놓은 상태입니다.

<img width="267" alt="스크린샷 2025-03-19 오후 5 18 57" src="https://github.com/user-attachments/assets/a6d3e617-c707-4389-8d6e-b6e9553c42a4" />


## 카테고리 이름 클릭시 카테고리 수정 가능하게 하기

```js
<h2 className="text-white subhead-semibold-18" onClick={handleStartEditing}>
```
카테고리 이름에 onClick에 `handleStartEditing` 달아주었습니다.

## 할 일 카드 생성시 디폴트로 날짜 캐러셀의 날짜로 할 일 카드 생성되기(캘린더 open되면 안됨)

최상단(HomePage.tsx)에서 관리되고 있는 selectedDate 상태가 startDate가 되도록 동기화 시켜주었습니다. 그래서 현재는 무조건 
selectedDate가 startDate가 됩니다. => 다른 날짜로 변경 불가능.
그래서 지금은 할 일 명을 입력하고 `enter`시에 캘린더가 열리지 않고 자동으로 selectedDate로 할 일 카드가 생성됩니다.

## 할 일 카드의 날짜 텍스트 클릭시 calendar 열리도록 수정

할 일 카드의 날짜 텍스트 클릭시 calendar가 열리지만 현재는 날짜 수정 api가 구현되지 않았기 때문에 단순히 열고 닫기만 가능합니다. 
캘린더를 닫을시에는 기간 토글, endDate 등등 모두 초기화 되도록 해주었습니다. 그래서 현재는 기간을 지정해주는 기능은 동작하지 않습니다!











## 🧐 새로 알게된 점

## 🤔 궁금한 점
날짜 캐러셀(DatePicker) 왼쪽, 오른쪽 버튼 클릭시 화면 깜빡임 발생하는데 해당 부분 추후에 개선하면 좋을 것 같습니다!

## 📸 스크린샷 / GIF / Link

> 날짜 캐러셀(DatePicker) 왼쪽, 오른쪽 버튼 클릭시 selectedDate도 -7일, +7일

https://github.com/user-attachments/assets/ca83a9f5-a848-474b-a7ce-bbd7e5e35fbe



> 카테고리 이름 클릭시 카테고리 이름 수정 가능

https://github.com/user-attachments/assets/8a8d69ad-be20-470c-b680-175d0483ab98



> 할 일 카드 생성시 디폴트로 날짜 캐러셀의 날짜로 할 일 카드 생성되기(캘린더 open되면 안됨) 

https://github.com/user-attachments/assets/15c69a09-2692-40ae-bf4e-7ce3a6a04474

> 할 일 카드의 날짜 텍스트 클릭했을 때 캘린더 열리기, 할 일 카드 연속 생성시 캘린더의 선택된 날짜 리셋 시켜주기

https://github.com/user-attachments/assets/2ff2b446-51ca-4bd5-beba-3e55ff1b0d33










