### PR TITLE
[ QA ] 온보딩 페이지 2차 QA사항 반영합니다.

### DIFF
--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -41,14 +41,14 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	const { mutateAsync: getUrlInfo, reset: resetGetUrlInfo, isError, isPending } = useGetUrlInfo();
 	const { mutate: postInterestArea } = usePostInterestArea();
 
-	const isSelectedUrl = (siteUrl: string) => {
+	const checkIsSelectedUrl = (siteUrl: string) => {
 		return selectedServices.some(
 			(service) => service.siteUrl.replace(/^https?:\/\//, '') === siteUrl.replace(/^https?:\/\//, ''),
 		);
 	};
 
 	const handleAddSelectedService = async (siteUrl: string) => {
-		const selected = isSelectedUrl(siteUrl);
+		const selected = checkIsSelectedUrl(siteUrl);
 
 		if (!siteUrl || selected) return;
 
@@ -62,7 +62,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	};
 
 	const handleAddRecommendedService = (urlInfo: AllowedSiteType) => {
-		const selected = isSelectedUrl(urlInfo.siteUrl);
+		const selected = checkIsSelectedUrl(urlInfo.siteUrl);
 
 		if (selected) {
 			return handleRemoveSelectedService(urlInfo.siteUrl);
@@ -167,11 +167,11 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 						value={inputUrl}
 						onKeyDown={handleKeyDown}
 						onChange={handleChangeInputUrl}
-						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError || isSelectedUrl(inputUrl)}
+						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError || checkIsSelectedUrl(inputUrl)}
 						errorMessage={
 							isError
 								? '유효하지 않은 주소입니다.'
-								: isSelectedUrl(inputUrl)
+								: checkIsSelectedUrl(inputUrl)
 									? '이미 등록된 url입니다.'
 									: '알맞은 형식의 url을 입력해 주세요.'
 						}

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -164,8 +164,14 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 						value={inputUrl}
 						onKeyDown={handleKeyDown}
 						onChange={handleChangeInputUrl}
-						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError}
-						errorMessage={isError ? '유효하지 않은 주소입니다.' : '알맞은 형식의 url을 입력해 주세요.'}
+						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError || isSelectedUrl(inputUrl)}
+						errorMessage={
+							isError
+								? '유효하지 않은 주소입니다.'
+								: isSelectedUrl(inputUrl)
+									? '이미 등록된 url입니다.'
+									: '알맞은 형식의 url을 입력해 주세요.'
+						}
 						isSuccess={inputSuccess}
 						successMessage={'url 입력에 성공했어요.'}
 						placeholder="직접 url 입력하기"

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -61,7 +61,9 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	const handleAddRecommendedService = (urlInfo: AllowedSiteType) => {
 		const selected = isSelectedUrl(urlInfo.siteUrl);
 
-		if (selected) return;
+		if (selected) {
+			return handleRemoveSelectedService(urlInfo.siteUrl);
+		}
 
 		setSelectedServices((prev) => [...prev, urlInfo]);
 	};

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -42,7 +42,9 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 	const { mutate: postInterestArea } = usePostInterestArea();
 
 	const isSelectedUrl = (siteUrl: string) => {
-		return selectedServices.some((service) => service.siteUrl === siteUrl);
+		return selectedServices.some(
+			(service) => service.siteUrl.replace(/^https?:\/\//, '') === siteUrl.replace(/^https?:\/\//, ''),
+		);
 	};
 
 	const handleAddSelectedService = async (siteUrl: string) => {
@@ -78,6 +80,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 			setInputSuccess(false);
 		}
 
+		resetGetUrlInfo();
 		setInputUrl(e.target.value);
 	};
 

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -56,6 +56,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 		const urlInfo = response?.data;
 
 		setSelectedServices((prev) => [...prev, urlInfo]);
+		setInputUrl('');
 	};
 
 	const handleAddRecommendedService = (urlInfo: AllowedSiteType) => {
@@ -165,7 +166,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 						onChange={handleChangeInputUrl}
 						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError}
 						errorMessage={isError ? '유효하지 않은 주소입니다.' : '알맞은 형식의 url을 입력해 주세요.'}
-						isSuccess={inputUrl.length > 0 && inputSuccess}
+						isSuccess={inputSuccess}
 						successMessage={'url 입력에 성공했어요.'}
 						placeholder="직접 url 입력하기"
 					>

--- a/src/pages/OnboardingPage/StepService/StepService.tsx
+++ b/src/pages/OnboardingPage/StepService/StepService.tsx
@@ -38,7 +38,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 
 	const navigate = useNavigate();
 
-	const { mutateAsync: getUrlInfo, reset: resetGetUrlInfo, isError, error, isPending } = useGetUrlInfo();
+	const { mutateAsync: getUrlInfo, reset: resetGetUrlInfo, isError, isPending } = useGetUrlInfo();
 	const { mutate: postInterestArea } = usePostInterestArea();
 
 	const isSelectedUrl = (siteUrl: string) => {
@@ -162,7 +162,7 @@ const StepService = ({ setStep, selectedField }: StepServiceProps) => {
 						onKeyDown={handleKeyDown}
 						onChange={handleChangeInputUrl}
 						isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError}
-						errorMessage={isError ? error.response?.data.message : '알맞은 형식의 url을 입력해 주세요.'}
+						errorMessage={isError ? '유효하지 않은 주소입니다.' : '알맞은 형식의 url을 입력해 주세요.'}
 						isSuccess={inputUrl.length > 0 && inputSuccess}
 						successMessage={'url 입력에 성공했어요.'}
 						placeholder="직접 url 입력하기"

--- a/src/pages/OnboardingPage/StepService/Tabs/Tabs.tsx
+++ b/src/pages/OnboardingPage/StepService/Tabs/Tabs.tsx
@@ -57,8 +57,10 @@ const TabsTrigger = ({ value }: TabsTriggerProps) => {
 
 	return (
 		<button
-			className={`flex h-[7rem] items-center justify-center text-white subhead-reg-22 ${
-				isActive ? 'border-b-[2px] border-b-mint-01' : 'border-b-[3px] border-b-gray-02'
+			className={`flex h-[7rem] items-center justify-center text-white hover:border-b-[0.3rem] hover:border-b-gray-03 ${
+				isActive
+					? 'border-b-[0.3rem] border-b-mint-01 head-bold-24'
+					: 'border-b-[0.2rem] border-b-gray-02 subhead-reg-22'
 			}`}
 			onClick={() => onChangeActiveTab(value)}
 		>

--- a/src/pages/OnboardingPage/StepStart/StepStart.tsx
+++ b/src/pages/OnboardingPage/StepStart/StepStart.tsx
@@ -13,11 +13,13 @@ interface StepStartProps {
 const StepStart = ({ setStep }: StepStartProps) => {
 	return (
 		<main className="flex w-full flex-col items-center justify-center">
-			<h1 className="mb-[2rem] text-center text-white title-bold-36">집중을 도와줄 모립세트를 만들어볼까요?</h1>
-			<p className="mb-[8.3rem] text-center text-gray-04 subhead-reg-22">
-				모립세트란 작업에 꼭 필요한 일만 할 수 있도록
+			<h1 className="mb-[2rem] text-center text-white title-bold-36">
+				집중을 도와줄 허용서비스 리스트를 만들어볼까요?
+			</h1>
+			<p className="body-med-24 mb-[8.3rem] text-center text-gray-04">
+				작업 할 때 필요한 서비스들만을 사용하며 오롯이 할 일에 집중해보세요.
 				<br />
-				설정하는 작업 시 사용 할 허용 서비스들의 모음을 말해요.
+				작업할 때 자주 쓰는 서비스들을 추천해드릴게요!
 			</p>
 			<OnboardingIcon className="mb-[8.3rem]" />
 

--- a/src/shared/constants/suggestedSites.ts
+++ b/src/shared/constants/suggestedSites.ts
@@ -19,7 +19,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://trello.com/en',
 		},
 		{
-			favicon: 'https://www.salesforce.com/favicon.ico',
+			favicon: `https://a.sfdcstatic.com/shared/images/c360-nav/salesforce-no-type-logo.svg`,
 			siteName: 'Salesforce',
 			pageName: 'Salesforce Korea',
 			siteUrl: 'https://www.salesforce.com/kr/?ir=1',
@@ -51,7 +51,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://unsplash.com/ko',
 		},
 		{
-			favicon: 'https://www.freepik.com/favicon.ico',
+			favicon: 'https://www.google.com/s2/favicons?domain=freepik.com&sz=128',
 			siteName: '프리픽',
 			pageName: 'Freepik',
 			siteUrl: 'https://www.freepik.com/',
@@ -75,8 +75,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://notefolio.net/',
 		},
 		{
-			favicon:
-				'https://cdn.dribbble.com/assets/favicon-452601365a822699d1d5db718ddf7499d036e8c2f7da69e85160a4d2f83534bd.ico',
+			favicon: `https://cdn.dribbble.com/assets/favicon-192x192-d70ad402693bdd1a8460da7f9f3c590e817da7369c5287789ac968cf6947d214.png`,
 			siteName: '드리블',
 			pageName: 'Dribbble',
 			siteUrl: 'https://dribbble.com/',
@@ -84,7 +83,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 	],
 	마케팅: [
 		{
-			favicon: 'https://newneek.co/favicon.ico',
+			favicon: 'https://newneek.co/icons/android-icon-192x192.png',
 			siteName: '뉴닉',
 			pageName: 'Newneek',
 			siteUrl: 'https://newneek.co/',
@@ -108,7 +107,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://www.mezzomedia.co.kr/',
 		},
 		{
-			favicon: 'https://www.nasmedia.co.kr/wp-content/themes/nasmedia/images/favicon/r-01.png',
+			favicon: 'https://www.nasmedia.co.kr/wp-content/themes/nasmedia/images/favicon/favicon-180.png',
 			siteName: '나스 미디어',
 			pageName: 'Nas Media',
 			siteUrl: 'https://www.nasmedia.co.kr/',
@@ -116,7 +115,7 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 	],
 	기획: [
 		{
-			favicon: 'https://disquiet.io/favicon.ico',
+			favicon: 'https://disquiet.io/favicons/favicon-96.png',
 			siteName: '디스콰이엇',
 			pageName: 'Disquiet',
 			siteUrl: 'https://disquiet.io/',
@@ -128,13 +127,13 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 			siteUrl: 'https://brunch.co.kr/',
 		},
 		{
-			favicon: 'https://www.notion.so/images/favicon.ico',
+			favicon: 'https://www.notion.so/images/logo-ios.png',
 			siteName: '노션',
 			pageName: 'Notion',
 			siteUrl: 'https://www.notion.so/',
 		},
 		{
-			favicon: 'https://www.producthunt.com/favicon.ico',
+			favicon: 'https://ph-static.imgix.net/ph-favicon-brand-500.ico?auto=format',
 			siteName: 'Product Hunt',
 			pageName: 'Product Hunt',
 			siteUrl: 'https://www.producthunt.com/',
@@ -180,19 +179,19 @@ export const SUGGESTED_STIES: Record<FieldType, AllowedSiteType[]> = {
 	],
 	공부: [
 		{
-			favicon: 'https://www.notion.so/images/favicon.ico',
+			favicon: 'https://www.notion.so/images/logo-ios.png',
 			siteName: '노션',
 			pageName: 'Notion',
 			siteUrl: 'https://www.notion.so/',
 		},
 		{
-			favicon: 'https://www.copykiller.com/favicon.ico',
+			favicon: 'https://www.copykiller.com/common/img/logo/favicon_ck_platform_32x32.png', // 더 개선 필요
 			siteName: '카피킬러라이트',
 			pageName: 'CopyKiller Lite',
 			siteUrl: 'https://www.copykiller.com/',
 		},
 		{
-			favicon: 'https://www.riss.kr/favicon.ico',
+			favicon: 'https://www.riss.kr/commons/images/favicon.ico',
 			siteName: 'RISS',
 			pageName: 'RISS',
 			siteUrl: 'https://www.riss.kr/',

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -1,5 +1,5 @@
 export const isUrlValid = (url: string): boolean => {
-	const urlPattern = /^(https?:\/\/)?([\w-]+(?:\.[\w-]+)+)(:[0-9]{1,5})?(\/[\w#!:.?+=&%@!\-/]*)?$/;
+	const urlPattern = /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+(\.[a-zA-Z]{2,})+)(:\d{1,5})?(\/[\w#!:.?+=&%@!\-/]*)?$/;
 	return urlPattern.test(url);
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,6 +55,9 @@ export default {
 				'.body-semibold-16-done': {
 					'@apply text-[1.6rem] font-semibold leading-140 line-through': '',
 				},
+				'.body-med-24': {
+					'@apply text-[2.4rem] font-medium leading-normal': '',
+				},
 				'.body-med-16': {
 					'@apply text-[1.6rem] font-medium leading-140': '',
 				},


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 파비콘 사진 화질 개선
- [x] Riss 파비콘 
- [x] 바디텍스트 행간 조정
- [x] 허용 서비스 리스트 등록 후 카드 재선택 시 삭제되도록 수정 
- [x] 비즈니스, 디자인, 마케팅 탭 인터랙션과 홈 캘린더 탭 인터랙션 동기화
- [x] url 관련 이슈
  - [x] UX 라이팅 수정 (잘못된 요청입니다 -> 유효하지 않은 주소입니다)
  - [x] url 등록 후 등록 완료 시 텍스트필드에서 url 사라지도록 수정
  - [x] 잘못된 url 입력 후 url 수정 시 등록 불가능
  - [x] url 중복 등록 시 에러 메세지 추가 
  - [x] 온전하지 않는 url도 등록됨 https://www.naver.co
  - [x] 동일 도메인에 대해 http, https 중복 등록되는 오류

## 🔧 작업 내용

## ✔️ 파비콘 사진 화질 개선 + Riss 파비콘

기존에 사이트 URL + favicon.ico 방식으로 파비콘을 가져와 파비콘의 화질이 낮은 문제가 있었습니다. 
이를 개선하기 위해 각 사이트의 SVG 형식 파비콘 URL을 확인한 후, 사용 가능하다면 해당 URL로 변경하여 화질을 개선했습니다.다만, SVG 자원이 등록되지 않은 파비콘은 추가적인 화질 개선이 어려워 기존 상태를 유지했습니다. 기능상의 버그는 아니라 일단 화질 개선 가능한 것들에 한해 작업해 두었고, 이후에 파비콘 자원을 어떻게 관리하면 좋을지 논의해 봐야 할 것 같아요!

## ✔️ 허용 서비스 리스트 등록 후 카드 재선택 시 삭제되도록 수정 + 잘못된 url 입력 후 url 수정 시 에러메시지 사라지도록 수정

handleAddRecommendedService에서 이미 등록된 카드를 재선택한 경우, handleRemoveSelectedService를 호출해 해당 카드가 허용 서비스 리스트에서 삭제되도록 수정했습니다. 

```javascript
const handleAddRecommendedService = (urlInfo: AllowedSiteType) => {
  const selected = isSelectedUrl(urlInfo.siteUrl);

  /* 추가된 부분 */
  if (selected) {
    return handleRemoveSelectedService(urlInfo.siteUrl);
  }

  setSelectedServices((prev) => [...prev, urlInfo]);
};
```

## ✔️ url 등록 후 등록 완료 시 텍스트필드에서 url 사라지도록 수정

URL이 허용 서비스 리스트에 추가된 후 InputUrl을 초기화하도록 수정했습니다.
이 과정에서 inputUrl이 빈 문자열('')이어도 성공 상태임을 고려하여, 기존의 inputUrl.length 조건문을 삭제했습니다.

```javascript
const handleAddSelectedService = async (siteUrl: string) => {
  const selected = isSelectedUrl(siteUrl);

  if (!siteUrl || selected) return;

  const response = await getUrlInfo({ siteUrl });

  setInputSuccess(true);
  const urlInfo = response?.data;

  setSelectedServices((prev) => [...prev, urlInfo]);
  /* 추가된 부분 */
  setInputUrl('');
};

<TextField
  {...}
  isError={(inputUrl.length > 0 && !isUrlValid(inputUrl)) || isError}
  // isSuccess={inputUrl.length > 0 && inputSuccess}
  isSuccess={inputSuccess}
  {...}
/>
```

## ✔️ 동일 도메인에 대해 http/https 중복 등록되는 오류 수정 +  잘못된 url 입력 후 url 수정 시 등록 불가능

https://naver.com, http://naver.com 둘 다 추가 가능한 문제가 있었습니다. 
replace 메서드를 추가해 http:// 와 https://를 제거한 후, 도메인 이름을 기준으로 비교하도록 수정했습니다. 
	
```javascript
  const isSelectedUrl = (siteUrl: string) => {
	  return selectedServices.some(
		  (service) => service.siteUrl.replace(/^https?:\/\//, '') === siteUrl.replace(/^https?:\/\//, ''),
	  );
  };
```

잘못된 url 입력 후 유효성 검사 실패 시 에러메시지가 제거되지 않는 문제가 있어 inputSuccess가 false 일 경우, resetGetUrlInfo()를 호출하도록 수정해 이를 해결했습니다. 

```javascript
const handleChangeInputUrl = (e: ChangeEvent<HTMLInputElement>) => {
	if (inputSuccess) {
		setInputSuccess(false);
	}

	 /* 추가된 부분 */
	resetGetUrlInfo();
	setInputUrl(e.target.value);
};

```

## ✔️ 온전하지 않는 url도 등록되는 경우

url 유효성 검증 패턴을 수정했습니다. 
www.naver.com이 유효하지 않다고 인식되거나, https://naver.c 와 같은 유효하지 않은 tld 패턴도 등록이 되는 문제가 있었습니다.
qwww의 포함 여부에 자유도를 두었고, TLD의 패턴을 구체적으로 수정하였습니다.

```javascript
/* 수정 전 */
const urlPattern = /^(https?:\/\/)?([\w-]+(?:\.[\w-]+)+)(:[0-9]{1,5})?(\/[\w#!:.?+=&%@!\-/]*)?$/;
/* 수정 후 */
const urlPattern = /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+(\.[a-zA-Z]{2,})+)(:\d{1,5})?(\/[\w#!:.?+=&%@!\-/]*)?$/;
```

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

## ✔️ 파비콘 사진 화질 개선 + 비즈니스, 디자인, 마케팅 탭 인터랙션과 홈 캘린더 탭 인터랙션 동기화
https://github.com/user-attachments/assets/102fb127-b7bc-4dde-a432-eafef93b37e3

## ✔️ 바디텍스트 행간 조정
![image](https://github.com/user-attachments/assets/ac3ed550-b00a-470b-a684-86849715c5a7)

## ✔️ 허용 서비스 리스트 등록 후 카드 재선택 시 삭제되도록 수정
https://github.com/user-attachments/assets/a93f2bb4-04f3-4158-a981-cf080b7b5549

## ✔️ url 등록 후 등록 완료 시 텍스트필드에서 url 사라지도록 수정 + UX 라이팅 수정 (잘못된 요청입니다 -> 유효하지 않은 주소입니다)
https://github.com/user-attachments/assets/3c0ccf13-aea6-40d9-8db5-e2627b638d8a

## ✔️ url 중복 등록 시 에러 메세지 추가 + 동일 도메인에 대해 http, https 중복 등록되는 오류
https://github.com/user-attachments/assets/2e757439-c451-4ed1-af16-065c34008a5e
