### PR TITLE
[ Feat ] 태스크 이름 및 날짜 수정 api를 연결합니다.

### DIFF
--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -280,6 +280,7 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
+										handleCalendarToggle={handleCalendarToggle}
 									/>
 								);
 							})}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -34,7 +34,7 @@ interface BoxCategoryProps {
 	getSelectedNumber: (id: number) => number;
 	addingComplete: boolean;
 	onDeleteCategory: (categoryId: number) => void;
-	onModifyCategory: (categoryId: number, newName: string) => void;
+	onPatchCategory: (categoryId: number, newName: string) => void;
 	isSelectedTodoExist?: boolean;
 	selectedDate: Dayjs;
 }
@@ -57,7 +57,7 @@ const BoxCategory = ({
 	getSelectedNumber,
 	addingComplete,
 	onDeleteCategory,
-	onModifyCategory,
+	onPatchCategory,
 	isSelectedTodoExist,
 	selectedDate,
 }: BoxCategoryProps) => {
@@ -184,7 +184,7 @@ const BoxCategory = ({
 
 	const handleFinishEditing = () => {
 		if (editedCategoryName.trim() && editedCategoryName !== title) {
-			onModifyCategory(id, editedCategoryName);
+			onPatchCategory(id, editedCategoryName);
 		}
 		setIsCategoryEditing(false);
 	};

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -1,4 +1,4 @@
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 
 import { KeyboardEvent, Suspense, lazy, useRef, useState } from 'react';
 
@@ -69,9 +69,32 @@ const BoxCategory = ({
 	const [isCalendarOpen, setIsCalendarOpen] = useState(false);
 	const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
 
+	const [calendarStartDate, setCalendarStartDate] = useState<Dayjs | null>(selectedDate);
+	const [calendarEndDate, setCalendarEndDate] = useState<Dayjs | null>(null);
+
 	const { mutate: patchTask } = usePatchTask();
 
 	const handleOpenTaskCalendar = (taskId: number) => {
+		const targetTask =
+			ongoingTodos.find((task) => task.id === taskId) || completedTodos.find((task) => task.id === taskId);
+
+		if (targetTask) {
+			setCalendarStartDate(dayjs(targetTask.startDate));
+
+			if (targetTask.endDate) {
+				setCalendarEndDate(dayjs(targetTask.endDate));
+
+				if (!isPeriodOn) {
+					handlePeriodToggle();
+				}
+			} else {
+				setCalendarEndDate(null);
+
+				if (isPeriodOn) {
+					handlePeriodToggle();
+				}
+			}
+		}
 		setSelectedTaskId(taskId);
 		setIsCalendarOpen(true);
 	};
@@ -102,8 +125,6 @@ const BoxCategory = ({
 
 	const handleCalendarToggle = () => {
 		setIsCalendarOpen((prev) => !prev);
-		handleEndDateInput(null);
-		handlePeriodEnd();
 	};
 
 	const handleOngoingTodoToggle = () => {
@@ -270,16 +291,20 @@ const BoxCategory = ({
 									>
 										<Calendar
 											isPeriodOn={isPeriodOn}
-											selectedStartDate={selectedDate ?? defaultDate}
-											selectedEndDate={selectedEndDate ?? null}
+											selectedStartDate={calendarStartDate ?? defaultDate}
+											selectedEndDate={calendarEndDate}
 											onStartDateInput={(newDate) => {
+												setCalendarStartDate(newDate);
 												if (!isPeriodOn) {
 													handleTaskDateChange(newDate, null);
+												} else {
+													setCalendarEndDate(null);
 												}
 											}}
 											onEndDateInput={(endDate) => {
-												if (isPeriodOn && selectedDate && endDate) {
-													handleTaskDateChange(selectedDate, endDate);
+												setCalendarEndDate(endDate);
+												if (isPeriodOn && calendarStartDate && endDate) {
+													handleTaskDateChange(calendarStartDate, endDate);
 												}
 											}}
 											isCalendarOpened={isCalendarOpened}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -74,9 +74,12 @@ const BoxCategory = ({
 
 	const { mutate: patchTask } = usePatchTask();
 
+	const getTargetTaskById = (taskId: number) => {
+		return ongoingTodos.find((task) => task.id === taskId) || completedTodos.find((task) => task.id === taskId);
+	};
+
 	const handleOpenTaskCalendar = (taskId: number) => {
-		const targetTask =
-			ongoingTodos.find((task) => task.id === taskId) || completedTodos.find((task) => task.id === taskId);
+		const targetTask = getTargetTaskById(taskId);
 
 		if (targetTask) {
 			setCalendarStartDate(dayjs(targetTask.startDate));
@@ -89,19 +92,17 @@ const BoxCategory = ({
 				}
 			} else {
 				setCalendarEndDate(null);
-
 				handlePeriodEnd();
 			}
 		}
+
 		setSelectedTaskId(taskId);
 		setIsCalendarOpen(true);
 	};
 
 	const handleTaskDateChange = (newDate: Dayjs | null, endDate?: Dayjs | null) => {
 		if (selectedTaskId) {
-			const targetTask =
-				ongoingTodos.find((task) => task.id === selectedTaskId) ||
-				completedTodos.find((task) => task.id === selectedTaskId);
+			const targetTask = getTargetTaskById(selectedTaskId);
 
 			if (targetTask) {
 				const newStartDate = newDate ? (format(newDate) as string) : targetTask.startDate;
@@ -116,6 +117,7 @@ const BoxCategory = ({
 				});
 			}
 		}
+
 		setIsCalendarOpen(false);
 		setSelectedTaskId(null);
 		handlePeriodEnd();

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -35,6 +35,7 @@ interface BoxCategoryProps {
 	addingComplete: boolean;
 	onDeleteCategory: (categoryId: number) => void;
 	onModifyCategory: (categoryId: number, newName: string) => void;
+	onPatchTask: (categoryId: number, name: string, startDate: string, endDate: string | null) => void;
 	isSelectedTodoExist?: boolean;
 	selectedDate: Dayjs;
 }
@@ -60,6 +61,7 @@ const BoxCategory = ({
 	onModifyCategory,
 	isSelectedTodoExist,
 	selectedDate,
+	onPatchTask,
 }: BoxCategoryProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
 	const [ongoingTodoToggle, setOngoingTodoToggle] = useState(true);
@@ -281,6 +283,7 @@ const BoxCategory = ({
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
 										handleCalendarToggle={handleCalendarToggle}
+										onPatchTask={onPatchTask}
 									/>
 								);
 							})}
@@ -304,6 +307,7 @@ const BoxCategory = ({
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
 										handleCalendarToggle={handleCalendarToggle}
+										onPatchTask={onPatchTask}
 									/>
 								))}
 							</ButtonTodoToggle>

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -217,7 +217,9 @@ const BoxCategory = ({
 	const handlePeriodToggleWrapper = () => {
 		if (!isPeriodOn) {
 			handlePeriodToggle();
-			setCalendarStartDate(null);
+			if (!calendarEndDate) {
+				setCalendarStartDate(null);
+			}
 		} else {
 			handlePeriodToggle();
 		}

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -90,9 +90,7 @@ const BoxCategory = ({
 			} else {
 				setCalendarEndDate(null);
 
-				if (isPeriodOn) {
-					handlePeriodToggle();
-				}
+				handlePeriodEnd();
 			}
 		}
 		setSelectedTaskId(taskId);
@@ -216,6 +214,15 @@ const BoxCategory = ({
 		}
 	};
 
+	const handlePeriodToggleWrapper = () => {
+		if (!isPeriodOn) {
+			handlePeriodToggle();
+			setCalendarStartDate(null);
+		} else {
+			handlePeriodToggle();
+		}
+	};
+
 	return (
 		<Spacer.Height
 			as="article"
@@ -291,7 +298,7 @@ const BoxCategory = ({
 									>
 										<Calendar
 											isPeriodOn={isPeriodOn}
-											selectedStartDate={calendarStartDate ?? defaultDate}
+											selectedStartDate={isPeriodOn ? calendarStartDate : calendarStartDate ?? defaultDate}
 											selectedEndDate={calendarEndDate}
 											onStartDateInput={(newDate) => {
 												setCalendarStartDate(newDate);
@@ -308,7 +315,7 @@ const BoxCategory = ({
 												}
 											}}
 											isCalendarOpened={isCalendarOpened}
-											onPeriodToggle={handlePeriodToggle}
+											onPeriodToggle={handlePeriodToggleWrapper}
 											clickOutSideCallback={handleCalendarToggle}
 										/>
 									</div>

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -15,7 +15,7 @@ import MeatballDefaultIcon from '@/shared/assets/svgs/common/ic_meatball_default
 import PlusIcon from '@/shared/assets/svgs/home/ic_plus.svg?react';
 
 import { usePostToggleTaskStatus } from '@/shared/apisV2/common/common.mutations';
-import { usePostCreateTask } from '@/shared/apisV2/home/home.mutations';
+import { usePatchTask, usePostCreateTask } from '@/shared/apisV2/home/home.mutations';
 
 import { useCalendar } from '../hooks/useCalendar';
 import BoxTodoInput from './BoxTodoInput/BoxTodoInput';
@@ -35,7 +35,6 @@ interface BoxCategoryProps {
 	addingComplete: boolean;
 	onDeleteCategory: (categoryId: number) => void;
 	onModifyCategory: (categoryId: number, newName: string) => void;
-	onPatchTask: (categoryId: number, name: string, startDate: string, endDate: string | null) => void;
 	isSelectedTodoExist?: boolean;
 	selectedDate: Dayjs;
 }
@@ -61,7 +60,6 @@ const BoxCategory = ({
 	onModifyCategory,
 	isSelectedTodoExist,
 	selectedDate,
-	onPatchTask,
 }: BoxCategoryProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
 	const [ongoingTodoToggle, setOngoingTodoToggle] = useState(true);
@@ -69,6 +67,38 @@ const BoxCategory = ({
 	const [isCategoryEditing, setIsCategoryEditing] = useState(false);
 	const [editedCategoryName, setEditedCategoryName] = useState(title);
 	const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+	const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+
+	const { mutate: patchTask } = usePatchTask();
+
+	const handleOpenTaskCalendar = (taskId: number) => {
+		setSelectedTaskId(taskId);
+		setIsCalendarOpen(true);
+	};
+
+	const handleTaskDateChange = (newDate: Dayjs | null, endDate?: Dayjs | null) => {
+		if (selectedTaskId) {
+			const targetTask =
+				ongoingTodos.find((task) => task.id === selectedTaskId) ||
+				completedTodos.find((task) => task.id === selectedTaskId);
+
+			if (targetTask) {
+				const newStartDate = newDate ? (format(newDate) as string) : targetTask.startDate;
+
+				const newEndDate = isPeriodOn ? (endDate ? (format(endDate) as string) : targetTask.endDate) : null;
+
+				patchTask({
+					taskId: selectedTaskId,
+					name: targetTask.name,
+					startDate: newStartDate,
+					endDate: newEndDate,
+				});
+			}
+		}
+		setIsCalendarOpen(false);
+		setSelectedTaskId(null);
+		handlePeriodEnd();
+	};
 
 	const handleCalendarToggle = () => {
 		setIsCalendarOpen((prev) => !prev);
@@ -105,7 +135,6 @@ const BoxCategory = ({
 		isCalendarOpened,
 		defaultDate,
 		handlePeriodToggle,
-		handleStartDateInput,
 		handleEndDateInput,
 		handlePeriodEnd,
 	} = useCalendar();
@@ -136,6 +165,10 @@ const BoxCategory = ({
 		import('@/shared/components/Calendar/Calendar').catch((error) => {
 			console.error('캘린더를 받아오는데 오류가 발생했습니다.', error);
 		});
+	};
+
+	const handlePatchTask = (taskId: number, name: string, startDate: string, endDate: string | null) => {
+		patchTask({ taskId, name, startDate, endDate });
 	};
 
 	const handleCalendarKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -239,8 +272,16 @@ const BoxCategory = ({
 											isPeriodOn={isPeriodOn}
 											selectedStartDate={selectedDate ?? defaultDate}
 											selectedEndDate={selectedEndDate ?? null}
-											onStartDateInput={handleStartDateInput}
-											onEndDateInput={handleEndDateInput}
+											onStartDateInput={(newDate) => {
+												if (!isPeriodOn) {
+													handleTaskDateChange(newDate, null);
+												}
+											}}
+											onEndDateInput={(endDate) => {
+												if (isPeriodOn && selectedDate && endDate) {
+													handleTaskDateChange(selectedDate, endDate);
+												}
+											}}
 											isCalendarOpened={isCalendarOpened}
 											onPeriodToggle={handlePeriodToggle}
 											clickOutSideCallback={handleCalendarToggle}
@@ -282,8 +323,8 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
-										handleCalendarToggle={handleCalendarToggle}
-										onPatchTask={onPatchTask}
+										handleCalendarToggle={() => handleOpenTaskCalendar(id)}
+										onPatchTask={handlePatchTask}
 									/>
 								);
 							})}
@@ -306,8 +347,7 @@ const BoxCategory = ({
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
 										isSelectedTodoExist={isSelectedTodoExist}
-										handleCalendarToggle={handleCalendarToggle}
-										onPatchTask={onPatchTask}
+										handleCalendarToggle={() => handleOpenTaskCalendar(id)}
 									/>
 								))}
 							</ButtonTodoToggle>

--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -83,15 +83,11 @@ const BoxCategory = ({
 
 		if (targetTask) {
 			setCalendarStartDate(dayjs(targetTask.startDate));
+			setCalendarEndDate(targetTask.endDate ? dayjs(targetTask.endDate) : null);
 
 			if (targetTask.endDate) {
-				setCalendarEndDate(dayjs(targetTask.endDate));
-
-				if (!isPeriodOn) {
-					handlePeriodToggle();
-				}
+				if (!isPeriodOn) handlePeriodToggle();
 			} else {
-				setCalendarEndDate(null);
 				handlePeriodEnd();
 			}
 		}
@@ -217,14 +213,10 @@ const BoxCategory = ({
 	};
 
 	const handlePeriodToggleWrapper = () => {
-		if (!isPeriodOn) {
-			handlePeriodToggle();
-			if (!calendarEndDate) {
-				setCalendarStartDate(null);
-			}
-		} else {
-			handlePeriodToggle();
+		if (!isPeriodOn && !calendarEndDate) {
+			setCalendarStartDate(null);
 		}
+		handlePeriodToggle();
 	};
 
 	return (

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -210,7 +210,7 @@ const HomePage = () => {
 		deleteCategory({ categoryId });
 	};
 
-	const handleModifyCategory = (categoryId: number, name: string) => {
+	const handlePatchCategory = (categoryId: number, name: string) => {
 		if (!name.trim()) return;
 		patchCategory({ categoryId, name: name });
 	};
@@ -329,7 +329,7 @@ const HomePage = () => {
 												getSelectedNumber={getSelectedNumber}
 												addingComplete={addingComplete}
 												onDeleteCategory={handleDeleteCategory}
-												onModifyCategory={handleModifyCategory}
+												onPatchCategory={handlePatchCategory}
 												isSelectedTodoExist={todayTodos.length > 0}
 												selectedDate={selectedDate}
 											/>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -86,7 +86,7 @@ const HomePage = () => {
 	const { mutate: addTodayTodos } = usePostAddTodayTodos();
 	const { mutate: deleteCategory } = useDeleteCategory();
 	const { mutate: addCategory } = useAddCategory();
-	const { mutate: modifyCategory } = usePatchCategory();
+	const { mutate: patchCategory } = usePatchCategory();
 
 	const navigate = useNavigate();
 
@@ -212,7 +212,7 @@ const HomePage = () => {
 
 	const handleModifyCategory = (categoryId: number, name: string) => {
 		if (!name.trim()) return;
-		modifyCategory({ categoryId, name: name });
+		patchCategory({ categoryId, name: name });
 	};
 
 	useEffect(() => {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -37,7 +37,6 @@ import {
 	useAddCategory,
 	useDeleteCategory,
 	usePatchCategory,
-	usePatchTask,
 	usePostAddTodayTodos,
 } from '@/shared/apisV2/home/home.mutations';
 import { useGetCategoryTask, useGetWorkTime } from '@/shared/apisV2/home/home.queries';
@@ -88,7 +87,6 @@ const HomePage = () => {
 	const { mutate: deleteCategory } = useDeleteCategory();
 	const { mutate: addCategory } = useAddCategory();
 	const { mutate: patchCategory } = usePatchCategory();
-	const { mutate: patchTask } = usePatchTask();
 
 	const navigate = useNavigate();
 
@@ -217,10 +215,6 @@ const HomePage = () => {
 		patchCategory({ categoryId, name: name });
 	};
 
-	const handlePatchTask = (taskId: number, name: string, startDate: string, endDate: string | null) => {
-		patchTask({ taskId, name, startDate, endDate });
-	};
-
 	useEffect(() => {
 		setTodayTodos(todayTodosStorageData);
 
@@ -338,7 +332,6 @@ const HomePage = () => {
 												onModifyCategory={handleModifyCategory}
 												isSelectedTodoExist={todayTodos.length > 0}
 												selectedDate={selectedDate}
-												onPatchTask={handlePatchTask}
 											/>
 										);
 									})}

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -36,7 +36,7 @@ import { friendKeys } from '@/shared/apisV2/friends/friends.keys';
 import {
 	useAddCategory,
 	useDeleteCategory,
-	useModifyCategory,
+	usePatchCategory,
 	usePostAddTodayTodos,
 } from '@/shared/apisV2/home/home.mutations';
 import { useGetCategoryTask, useGetWorkTime } from '@/shared/apisV2/home/home.queries';
@@ -86,7 +86,7 @@ const HomePage = () => {
 	const { mutate: addTodayTodos } = usePostAddTodayTodos();
 	const { mutate: deleteCategory } = useDeleteCategory();
 	const { mutate: addCategory } = useAddCategory();
-	const { mutate: modifyCategory } = useModifyCategory();
+	const { mutate: modifyCategory } = usePatchCategory();
 
 	const navigate = useNavigate();
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -37,6 +37,7 @@ import {
 	useAddCategory,
 	useDeleteCategory,
 	usePatchCategory,
+	usePatchTask,
 	usePostAddTodayTodos,
 } from '@/shared/apisV2/home/home.mutations';
 import { useGetCategoryTask, useGetWorkTime } from '@/shared/apisV2/home/home.queries';
@@ -87,6 +88,7 @@ const HomePage = () => {
 	const { mutate: deleteCategory } = useDeleteCategory();
 	const { mutate: addCategory } = useAddCategory();
 	const { mutate: patchCategory } = usePatchCategory();
+	const { mutate: patchTask } = usePatchTask();
 
 	const navigate = useNavigate();
 
@@ -215,6 +217,10 @@ const HomePage = () => {
 		patchCategory({ categoryId, name: name });
 	};
 
+	const handlePatchTask = (taskId: number, name: string, startDate: string, endDate: string | null) => {
+		patchTask({ taskId, name, startDate, endDate });
+	};
+
 	useEffect(() => {
 		setTodayTodos(todayTodosStorageData);
 
@@ -332,6 +338,7 @@ const HomePage = () => {
 												onModifyCategory={handleModifyCategory}
 												isSelectedTodoExist={todayTodos.length > 0}
 												selectedDate={selectedDate}
+												onPatchTask={handlePatchTask}
 											/>
 										);
 									})}

--- a/src/shared/apisV2/home/home.api.ts
+++ b/src/shared/apisV2/home/home.api.ts
@@ -73,7 +73,7 @@ export const patchCategory = async ({ categoryId, name }: PatchCategoryReq) => {
 };
 
 export const patchTask = async ({ taskId, name, startDate, endDate }: PatchTaskReq) => {
-	const { data } = await authClient.patch(HOME_ENDPOINT.PATCH_TASK.replace(':categoryId', String(taskId)), {
+	const { data } = await authClient.patch(HOME_ENDPOINT.PATCH_TASK.replace(':taskId', String(taskId)), {
 		name,
 		startDate,
 		endDate,

--- a/src/shared/apisV2/home/home.api.ts
+++ b/src/shared/apisV2/home/home.api.ts
@@ -5,7 +5,7 @@ import {
 	GetCategoryTaskRes,
 	GetWorkTimeReq,
 	GetWorkTimeRes,
-	ModifyCategoryReq,
+	PatchCategoryReq,
 	PostAddCategoryReq,
 	PostCreateTaskReq,
 	postAddTodayTodosReq,
@@ -21,7 +21,7 @@ export const HOME_ENDPOINT = {
 	POST_ADD_CATEGORY: 'api/v2/categories',
 	DELETE_CATEGORY: 'api/v2/categories/:categoryId',
 	DELETE_TASK: 'api/v2/tasks/:taskId',
-	MODIFY_CATEGORY: 'api/v2/categories/:categoryId',
+	PATCH_CATEGORY: 'api/v2/categories/:categoryId',
 };
 
 export const getCategoryTask = async ({ startDate, endDate }: GetCategoryTaskReq): Promise<GetCategoryTaskRes> => {
@@ -63,8 +63,8 @@ export const deleteCategory = async ({ categoryId }: DeleteCategoryReq) => {
 	return data;
 };
 
-export const modifyCategory = async ({ categoryId, name }: ModifyCategoryReq) => {
-	const { data } = await authClient.patch(HOME_ENDPOINT.MODIFY_CATEGORY.replace(':categoryId', String(categoryId)), {
+export const patchCategory = async ({ categoryId, name }: PatchCategoryReq) => {
+	const { data } = await authClient.patch(HOME_ENDPOINT.PATCH_CATEGORY.replace(':categoryId', String(categoryId)), {
 		name,
 	});
 	return data;

--- a/src/shared/apisV2/home/home.api.ts
+++ b/src/shared/apisV2/home/home.api.ts
@@ -6,6 +6,7 @@ import {
 	GetWorkTimeReq,
 	GetWorkTimeRes,
 	PatchCategoryReq,
+	PatchTaskReq,
 	PostAddCategoryReq,
 	PostCreateTaskReq,
 	postAddTodayTodosReq,
@@ -22,6 +23,7 @@ export const HOME_ENDPOINT = {
 	DELETE_CATEGORY: 'api/v2/categories/:categoryId',
 	DELETE_TASK: 'api/v2/tasks/:taskId',
 	PATCH_CATEGORY: 'api/v2/categories/:categoryId',
+	PATCH_TASK: 'api/v2/tasks/:taskId',
 };
 
 export const getCategoryTask = async ({ startDate, endDate }: GetCategoryTaskReq): Promise<GetCategoryTaskRes> => {
@@ -66,6 +68,15 @@ export const deleteCategory = async ({ categoryId }: DeleteCategoryReq) => {
 export const patchCategory = async ({ categoryId, name }: PatchCategoryReq) => {
 	const { data } = await authClient.patch(HOME_ENDPOINT.PATCH_CATEGORY.replace(':categoryId', String(categoryId)), {
 		name,
+	});
+	return data;
+};
+
+export const patchTask = async ({ taskId, name, startDate, endDate }: PatchTaskReq) => {
+	const { data } = await authClient.patch(HOME_ENDPOINT.PATCH_TASK.replace(':categoryId', String(taskId)), {
+		name,
+		startDate,
+		endDate,
 	});
 	return data;
 };

--- a/src/shared/apisV2/home/home.mutations.ts
+++ b/src/shared/apisV2/home/home.mutations.ts
@@ -4,7 +4,7 @@ import { timerKeys } from '../timer/timer.keys';
 import {
 	deleteCategory,
 	deleteTask,
-	modifyCategory,
+	patchCategory,
 	postAddCategory,
 	postAddTodayTodos,
 	postCreateTask,
@@ -62,11 +62,11 @@ export const useDeleteTask = () => {
 	});
 };
 
-export const useModifyCategory = () => {
+export const usePatchCategory = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: modifyCategory,
+		mutationFn: patchCategory,
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: homeKeys.task });
 		},

--- a/src/shared/apisV2/home/home.mutations.ts
+++ b/src/shared/apisV2/home/home.mutations.ts
@@ -5,6 +5,7 @@ import {
 	deleteCategory,
 	deleteTask,
 	patchCategory,
+	patchTask,
 	postAddCategory,
 	postAddTodayTodos,
 	postCreateTask,
@@ -67,6 +68,17 @@ export const usePatchCategory = () => {
 
 	return useMutation({
 		mutationFn: patchCategory,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: homeKeys.task });
+		},
+	});
+};
+
+export const usePatchTask = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: patchTask,
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: homeKeys.task });
 		},

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent, KeyboardEvent, MouseEvent, useState } from 'react';
+
 import { formatSeconds } from '@/shared/utils/time';
 
 import type { TaskType } from '@/shared/types/tasks';
@@ -31,7 +33,9 @@ interface BoxTodoProps {
 	timerIncreasedTime?: number;
 	isSelectedTodoExist?: boolean;
 	handleCalendarToggle?: () => void;
+	onPatchTask?: (taskId: number, name: string, startDate: string, endDate: string | null) => void;
 }
+
 const BoxTodo = ({
 	id,
 	name,
@@ -49,6 +53,7 @@ const BoxTodo = ({
 	timerIncreasedTime,
 	isSelectedTodoExist,
 	handleCalendarToggle,
+	onPatchTask,
 }: BoxTodoProps) => {
 	const { mutate: deleteTask } = useDeleteTask();
 
@@ -58,7 +63,6 @@ const BoxTodo = ({
 
 	const nameStyle = isComplete ? 'line-through' : '';
 	const CheckBoxIcon = isComplete ? <CheckBoxFillIcon /> : <CheckBoxBlankIcon />;
-
 	const TimeIcon = elapsedTime ? <TimeFillIcon /> : <TimeLineIcon />;
 	const timeTextClass = elapsedTime ? 'text-mint-01' : 'text-gray-04';
 
@@ -70,19 +74,44 @@ const BoxTodo = ({
 				: ' bg-gray-bg-01';
 
 	const duration = formattedendDate ? `${formattedstartDate}~${formattedendDate}` : formattedstartDate;
-
 	const clickStyle = clickable && !addingComplete ? 'cursor-pointer' : 'cursor-default';
 
 	const handleClickTodo = () => {
 		if (addingComplete) return;
-
 		if (clickable && updateTodayTodos) updateTodayTodos({ id, name, startDate, endDate, elapsedTime });
-		else if (onClick) {
-			onClick();
-		}
+		else if (onClick) onClick();
 	};
 
 	const disableBtnStyle = clickable !== addingComplete ? 'pointer-events-none' : '';
+
+	const [isEditing, setIsEditing] = useState(false);
+	const [editedName, setEditedName] = useState(name);
+
+	const handleNameClick = (e: MouseEvent<HTMLHeadingElement>) => {
+		e.stopPropagation();
+		setIsEditing(true);
+	};
+
+	const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+		setEditedName(e.target.value);
+	};
+
+	const finishEditing = () => {
+		if (editedName.trim() && editedName !== name && onPatchTask) {
+			onPatchTask(id, editedName, startDate, endDate);
+		}
+		setIsEditing(false);
+	};
+
+	const handleNameBlur = () => {
+		finishEditing();
+	};
+
+	const handleNameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter') {
+			finishEditing();
+		}
+	};
 
 	return (
 		<div
@@ -95,7 +124,23 @@ const BoxTodo = ({
 						<button onClick={onToggleComplete} className={disableBtnStyle}>
 							{CheckBoxIcon}
 						</button>
-						<h3 className={`mt-[0.42rem] text-white body-semibold-16 ${nameStyle} truncate`}>{name}</h3>
+						{isEditing ? (
+							<input
+								className="mt-[0.42rem] w-[27.8rem] border-b-[0.1rem] border-b-white bg-transparent text-gray-04 detail-reg-14 placeholder:text-gray-04 focus:outline-none"
+								value={editedName}
+								onChange={handleNameChange}
+								onBlur={handleNameBlur}
+								onKeyDown={handleNameKeyDown}
+								autoFocus
+							/>
+						) : (
+							<h3
+								className={`mt-[0.42rem] text-white body-semibold-16 ${nameStyle} truncate`}
+								onClick={handleNameClick}
+							>
+								{name}
+							</h3>
+						)}
 					</div>
 					{!isSelectedTodoExist && !addingComplete && (
 						<Dropdown>
@@ -120,7 +165,6 @@ const BoxTodo = ({
 						<ButtonCalendarIcon />
 						<p className="mt-[0.3rem] text-gray-04 detail-reg-12">{duration}</p>
 					</button>
-
 					<div className="flex items-center gap-[0.6rem]">
 						{TimeIcon}
 						<p className={`mt-[0.3rem] detail-reg-12 ${timeTextClass}`}>{formattedTime}</p>

--- a/src/shared/components/Calendar/Calendar.tsx
+++ b/src/shared/components/Calendar/Calendar.tsx
@@ -145,7 +145,7 @@ const Calendar = ({
 
 					<hr className={STYLES.divideLine} />
 					<div className={`${STYLES.defaultToggle}`}>
-						<h3 className={STYLES.toggleText}>종료 날짜</h3>
+						<h3 className={STYLES.toggleText}>기간 설정</h3>
 						<ButtonStatusToggle isToggleOn={isPeriodOn} onToggle={onPeriodToggle} />
 					</div>
 				</div>

--- a/src/shared/components/Calendar/Calendar.tsx
+++ b/src/shared/components/Calendar/Calendar.tsx
@@ -71,7 +71,12 @@ const Calendar = ({
 	const handleDateChange = (date: Date | null) => {
 		if (date) {
 			const dayjsDate = dayjs(date);
+
 			onStartDateInput(dayjsDate);
+
+			if (!isPeriodOn && onEndDateInput) {
+				onEndDateInput(null);
+			}
 		} else {
 			onStartDateInput(null);
 		}
@@ -79,8 +84,14 @@ const Calendar = ({
 
 	const handlePeriodChange = (dates: [Date | null, Date | null]) => {
 		const [start, end] = dates;
-		onStartDateInput(start ? dayjs(start) : null);
-		onEndDateInput(end ? dayjs(end) : null);
+		const startDayjs = start ? dayjs(start) : null;
+		const endDayjs = end ? dayjs(end) : null;
+
+		onStartDateInput(startDayjs);
+
+		if (startDayjs && endDayjs) {
+			onEndDateInput(endDayjs);
+		}
 	};
 
 	return (

--- a/src/shared/components/Calendar/Calendar.tsx
+++ b/src/shared/components/Calendar/Calendar.tsx
@@ -83,12 +83,17 @@ const Calendar = ({
 	};
 
 	const handlePeriodChange = (dates: [Date | null, Date | null]) => {
-		const [start, end] = dates;
-		const startDayjs = start ? dayjs(start) : null;
-		const endDayjs = end ? dayjs(end) : null;
+		const [newStart, newEnd] = dates;
 
+		if (selectedStartDate && selectedEndDate && newStart) {
+			onStartDateInput(dayjs(newStart));
+			onEndDateInput(null);
+			return;
+		}
+
+		const startDayjs = newStart ? dayjs(newStart) : null;
+		const endDayjs = newEnd ? dayjs(newEnd) : null;
 		onStartDateInput(startDayjs);
-
 		if (startDayjs && endDayjs) {
 			onEndDateInput(endDayjs);
 		}

--- a/src/shared/types/api/home.ts
+++ b/src/shared/types/api/home.ts
@@ -63,7 +63,7 @@ export interface DeleteTaskReq {
 	taskId: number;
 }
 
-export interface ModifyCategoryReq {
+export interface PatchCategoryReq {
 	categoryId: number;
 	name: string;
 }

--- a/src/shared/types/api/home.ts
+++ b/src/shared/types/api/home.ts
@@ -67,3 +67,10 @@ export interface PatchCategoryReq {
 	categoryId: number;
 	name: string;
 }
+
+export interface PatchTaskReq {
+	taskId: number;
+	name: string;
+	startDate: string;
+	endDate: string | null;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #296 

## ✅ 작업 리스트

- [x] 할 일 카드 이름 클릭시 이름 수정
- [x] 할 일 카드 날짜 클릭시 날짜 수정
- [x] 할 일 카드의 선택되어있는 날짜 상태로 관리
- [x] 기존 카테고리 수정(ModifyCategory) 네이밍 patch로 통일

## 🔧 작업 내용
### 할 일 카드 이름 클릭시 이름 수정
카테고리 이름 수정과 마찬가지로, 할일카드 이름 클릭시 최초에 할일카드 생성할시 나오는 input창이 열리도록 하고 수정할 수 있도록 하였습니다.
서버 개발자분의 요청으로 "할 일 카드이름 변경시"에 해당 할 일 카드의 `startDate`와 `endDate`는 기존에 등록되어있는 것을 담아서 보내주도록 하였습니다.

### 할 일 카드 날짜 클릭시 날짜 수정

<img width="223" alt="스크린샷 2025-03-24 오전 3 22 09" src="https://github.com/user-attachments/assets/19e9ea18-307d-47a5-9e86-19c7c0e54219" />

총 네가지의 플로우가 존재합니다.
1. 단일 날짜 할 일 카드 -> 단일 날짜 할 일카드로 날짜 수정시(기간 토글 off) : 처음 캘린더 open시 할 일 카드의 날짜가 selected되어있으며 클릭한 날짜가 `startDate`가되고, `endDate`는 자동으로 null이 된다. 즉, 클릭한 날짜로 할 일 카드의 날짜가 변경된다.
2. 기간 설정이 되어있는 할일 카드 -> 기간 설정이 되어있는 할 일 카드로 날짜 수정시(기간 토글 on) : 캘린더 open시 기간 설정되어있는대로 캘린더에 반영되어있으며 첫번째 클릭하는 날짜가 `startDate` 다음으로 누르는 날짜가 `endDate`가 된다.
3. 단일 날짜 할 일 카드 -> 기간 설정이 되어있는 할일 카드로 날짜 수정시 : 처음 캘린더 open시 할 일 카드의 단일 날짜가 selected되어있으며 기간 토글 클릭시 `stardate`와 `endDate`를 순차적으로 클릭해야함.
4. 기간 설정이 되어있는 할일 카드 -> 단일 날짜 할 일 카드로 날짜 수정시 : 캘린더 open시 기간 설정되어있는대로 캘린더에 반영되어있으며 
기간 토글 클릭후 날짜 하나만 선택해도 해당 날짜로 단일 날짜 할 일 카드로 날짜 생성.

해당 플로우는 스카이스캐너와 동일하니 참고하시면 좋습니다.

기획과 논의후 생각보다 플로우가 복잡하고, 고려해야하는 부분이 많아서 코드가 더러워진것 같아서 아쉽네요. 피드백 적극적으로 해주세요!


## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
> 할 일 카드 이름 수정

https://github.com/user-attachments/assets/788bfcaf-f544-4587-9b2c-a3a8a00ab3a7

> 할 일 카드 날짜 수정

https://github.com/user-attachments/assets/5ce095de-c4d3-4d42-aec8-aa78a0c5a4a9








