### PR TITLE
[ QA ] 허용서비스 2차 QA 반영

### DIFF
--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -64,6 +64,7 @@ const AllowedServicePage = () => {
 		setActiveGroupId(null);
 		setTitleInput('');
 		setSelectedColor('#868C93');
+		resetUrlInput();
 	};
 
 	const { data: allowedServiceList } = useGetAllowedServiceList({ connectType: currentTap });
@@ -88,6 +89,7 @@ const AllowedServicePage = () => {
 
 	const handleSelectActiveGroupId = (activeGroupId: number | null) => {
 		setActiveGroupId(activeGroupId);
+		resetUrlInput();
 	};
 
 	const handleSelectColor = (hashColor: ColorPaletteType) => {

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -116,10 +116,27 @@ const AllowedServicePage = () => {
 
 	const handleAddAllowedServiceGroup = () => {
 		if (titleInput.length > 0) {
-			postAddAllowedServiceGroup({
-				name: titleInput,
-				colorCode: selectedColor,
-			});
+			postAddAllowedServiceGroup(
+				{
+					name: titleInput,
+					colorCode: selectedColor,
+				},
+				{
+					onSuccess: (response) => {
+						setActiveGroupId(response.data.id);
+					},
+				},
+			);
+		}
+	};
+
+	const handleKeyDownTitleInput = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+			if (activeGroupId === null) {
+				handleAddAllowedServiceGroup();
+			} else {
+				handleChangeAllowedServiceGroupName();
+			}
 		}
 	};
 
@@ -173,7 +190,7 @@ const AllowedServicePage = () => {
 		});
 	};
 
-	const handleKeyDownTitleInput = (e: KeyboardEvent<HTMLInputElement>) => {
+	const handleKeyDownUrlInput = (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
 			handleAddAllowedService(urlInput, activeGroupId);
 		}
@@ -181,7 +198,7 @@ const AllowedServicePage = () => {
 
 	// NOTE: 첫 렌더링 시 api를 통해 받은 첫번째 allowed service group id를 activeGroupId로 설정
 	useEffect(() => {
-		if (!activeGroupId && allowedServiceList && allowedServiceList?.data.length > 0) {
+		if (activeGroupId === null && allowedServiceList && allowedServiceList?.data.length > 0) {
 			setActiveGroupId(allowedServiceList.data[0].id);
 		}
 	}, [allowedServiceList]);
@@ -250,6 +267,7 @@ const AllowedServicePage = () => {
 							<AllowedServiceGroupDetail.Input
 								value={titleInput}
 								onChange={handleChangeTitleInput}
+								onKeyDown={handleKeyDownTitleInput}
 								placeholder="허용서비스 세트의 이름을 입력해주세요."
 							/>
 						</AllowedServiceGroupDetail.Header>
@@ -266,7 +284,7 @@ const AllowedServicePage = () => {
 						<AllowedServiceGroupDetail.Content>
 							<TextField
 								value={urlInput}
-								onKeyDown={handleKeyDownTitleInput}
+								onKeyDown={handleKeyDownUrlInput}
 								onChange={handleChangeUrlInput}
 								isError={(urlInput.length > 0 && !isUrlValid(urlInput)) || isError}
 								errorMessage={isError ? error.response?.data.message : '알맞은 형식의 url을 입력해 주세요.'}

--- a/src/pages/AllowedServicePage/RecommendService/RecommendService.tsx
+++ b/src/pages/AllowedServicePage/RecommendService/RecommendService.tsx
@@ -17,7 +17,7 @@ const RecommendServiceItem = ({ recommendSite, ...props }: RecommendServiceItemP
 	return (
 		<button
 			{...props}
-			className="flex w-[23.9rem] flex-shrink-0 items-center gap-[1.5rem] rounded-[8px] bg-gray-bg-01 p-[2rem]"
+			className="flex w-[23.9rem] flex-shrink-0 items-center gap-[1.5rem] rounded-[8px] bg-gray-bg-01 p-[2rem] hover:bg-gray-bg-04 active:bg-gray-bg-02"
 		>
 			<img
 				src={getServiceFavicon(recommendSite.siteUrl)}


### PR DESCRIPTION

## 🔥 Related Issues

## ✅ 작업 리스트

- [x] 새로운 허용 서비스 제목 입력 후 엔터 or 외부 영역 클릭시 새로 생성된 허용서비스가 active 되도록 변경
- [x] 추천서비스 카드에 인터렉션(호버, 셀렉트 등) 추가
- [x] 허용서비스 세트 생성 시 이전에 있던 오류메시지 남아있던 오류 해결

## 🔧 작업 내용
> 새로운 허용 서비스 제목 입력 후 엔터 or 외부 영역 클릭시 새로 생성된 허용서비스가 active 되도록 변경

https://github.com/user-attachments/assets/2f4952d0-5604-408b-8118-e029298adb68

피그마 보니까 새로운 허용 서비스 제목 입력 후 엔터 or 외부 영역 클릭시 새로 생성된 허용서비스가 리스트의 가장 아래로 오는게 맞아서 정렬 순서는 그냥 두고, 새로 생성된 허용서비스가 active 되도록 해주었습니다!
handleAddAllowedServiceGroup 함수의 onSuccess 콜백에서 새로 생성된 그룹의 ID를 활성 그룹으로 설정함


> 추천서비스 카드에 인터렉션(hover, press 등) 추가

https://github.com/user-attachments/assets/8acfaeb0-611a-4dd5-9340-3def1ae52c06

> 허용서비스 세트 생성 시 이전에 있던 오류메시지 없애줌

https://github.com/user-attachments/assets/2ed1ebbd-fff6-4900-874f-0a243626d0d7

active group 선택하는 핸들러 함수 안에 resetUrl()호출되도록 했습니다!


