### PR TITLE
[ QA ] polling 함수 추가 및 주기를 설정합니다.

### DIFF
--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -17,8 +17,12 @@ import HomeIcon from '@/shared/assets/svgs/btn_home.svg?react';
 
 import { ROUTES_CONFIG } from '@/router/routesConfig';
 
-import { usePostUpdateTimerInfo, usePostUpdateTimerInfoWithPolling } from '@/shared/apisV2/timer/timer.mutations';
-import { useGetPopoverAllowedServiceList, useGetTimerTodos } from '@/shared/apisV2/timer/timer.queries';
+import { usePostUpdateTimerInfo } from '@/shared/apisV2/timer/timer.mutations';
+import {
+	useGetPopoverAllowedServiceList,
+	useGetTimerTodos,
+	useGetUpdateTimerInfo,
+} from '@/shared/apisV2/timer/timer.queries';
 
 import Carousel from './Carousel/Carousel';
 import PopoverAllowedService from './PopoverAllowedService/PopoverAllowedService';
@@ -148,8 +152,8 @@ const TimerPage = () => {
 		}
 	}, [allowedServiceList]);
 
-	usePostUpdateTimerInfoWithPolling({
-		taskId: selectedTodoId,
+	useGetUpdateTimerInfo({
+		taskId: selectedTodoId!,
 		elapsedTime: timerIncreasedTime,
 		targetDate: formattedTodayDate,
 		timerStatus: isPlaying ? 'RUNNING' : 'PAUSED',

--- a/src/shared/apisV2/common/common.queries.ts
+++ b/src/shared/apisV2/common/common.queries.ts
@@ -7,7 +7,7 @@ export const useGetHeartBeat = () => {
 	return useQuery({
 		queryKey: commonKeys.heartBeat(),
 		queryFn: getHeartBeat,
-		refetchInterval: 1000,
+		refetchInterval: 30000,
 		refetchIntervalInBackground: true,
 	});
 };

--- a/src/shared/apisV2/timer/timer.api.ts
+++ b/src/shared/apisV2/timer/timer.api.ts
@@ -1,8 +1,9 @@
-import {
+import type {
 	GetPopoverAllowedServiceListRes,
 	GetTimerFriendsRes,
 	GetTimerTodosReq,
 	GetTimerTodosRes,
+	GetUpdateTimerInfoReq,
 	PostApplyAllowedServiceGroupReq,
 	PostUpdateTimerInfoReq,
 } from '@/shared/types/api/timer';
@@ -15,6 +16,7 @@ const TIMER_ENDPOINT = {
 	GET_POPOVER_ALLOWED_SERVICE_LIST: 'api/v2/timer/allowedGroups',
 	POST_APPLY_ALLOWED_SERVICE_GROUP: 'api/v2/timer/allowedGroups',
 	POST_TIMER_INFO_UPDATE: 'api/v2/timer/sync',
+	GET_TIMER_INFO_UPDATE: 'api/v2/timer/ping',
 };
 
 export const getTimerTodos = async ({ targetDate }: GetTimerTodosReq): Promise<GetTimerTodosRes> => {
@@ -43,6 +45,13 @@ export const postUpdateTimerInfo = async ({ taskId, elapsedTime, targetDate, tim
 		elapsedTime,
 		targetDate,
 		timerStatus,
+	});
+	return data;
+};
+
+export const getUpdateTimerInfo = async ({ taskId, elapsedTime, targetDate, timerStatus }: GetUpdateTimerInfoReq) => {
+	const { data } = await authClient.get(TIMER_ENDPOINT.GET_TIMER_INFO_UPDATE, {
+		params: { taskId, elapsedTime, targetDate, timerStatus },
 	});
 	return data;
 };

--- a/src/shared/apisV2/timer/timer.keys.ts
+++ b/src/shared/apisV2/timer/timer.keys.ts
@@ -1,8 +1,16 @@
-import { GetTimerTodosReq } from '@/shared/types/api/timer';
+import { GetTimerTodosReq, GetUpdateTimerInfoReq } from '@/shared/types/api/timer';
 
 export const timerKeys = {
 	timer: ['timer'] as const,
 	todos: ({ targetDate }: GetTimerTodosReq) => [...timerKeys.timer, targetDate],
 	friends: () => [...timerKeys.timer, 'friends'],
 	popover: () => [...timerKeys.timer, 'popover'],
+	updateTimerInfo: ({ taskId, elapsedTime, targetDate, timerStatus }: GetUpdateTimerInfoReq) => [
+		...timerKeys.timer,
+		'updateTimerInfo',
+		taskId,
+		elapsedTime,
+		targetDate,
+		timerStatus,
+	],
 };

--- a/src/shared/apisV2/timer/timer.mutations.ts
+++ b/src/shared/apisV2/timer/timer.mutations.ts
@@ -1,8 +1,6 @@
-import { useEffect } from 'react';
-
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { PostApplyAllowedServiceGroupReq, PostUpdateTimerInfoReq } from '@/shared/types/api/timer';
+import { PostApplyAllowedServiceGroupReq } from '@/shared/types/api/timer';
 
 import { postApplyAllowedServiceGroup, postUpdateTimerInfo } from './timer.api';
 import { timerKeys } from './timer.keys';
@@ -27,26 +25,4 @@ export const usePostUpdateTimerInfo = () => {
 			queryClient.invalidateQueries({ queryKey: timerKeys.timer });
 		},
 	});
-};
-
-export const usePostUpdateTimerInfoWithPolling = ({
-	taskId,
-	elapsedTime,
-	targetDate,
-	timerStatus,
-}: Omit<PostUpdateTimerInfoReq, 'taskId'> & { taskId: number | null }) => {
-	const mutation = usePostUpdateTimerInfo();
-	const { mutate: updateTimerInfo } = mutation;
-
-	useEffect(() => {
-		if (taskId) {
-			const intervalId = setInterval(() => {
-				updateTimerInfo({ taskId, elapsedTime, targetDate, timerStatus });
-			}, 1000);
-
-			return () => clearInterval(intervalId);
-		}
-	}, [taskId, elapsedTime, targetDate, timerStatus, updateTimerInfo]);
-
-	return mutation;
 };

--- a/src/shared/apisV2/timer/timer.queries.ts
+++ b/src/shared/apisV2/timer/timer.queries.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { GetTimerTodosReq } from '@/shared/types/api/timer';
+import { GetTimerTodosReq, GetUpdateTimerInfoReq } from '@/shared/types/api/timer';
 
-import { getPopoverAllowedServiceList, getTimerFriends, getTimerTodos } from './timer.api';
+import { getPopoverAllowedServiceList, getTimerFriends, getTimerTodos, getUpdateTimerInfo } from './timer.api';
 import { timerKeys } from './timer.keys';
 
 export const useGetTimerTodos = ({ targetDate }: GetTimerTodosReq) => {
@@ -16,6 +16,7 @@ export const useGetTimerFriends = () => {
 	return useQuery({
 		queryKey: timerKeys.friends(),
 		queryFn: getTimerFriends,
+		refetchInterval: 58000,
 	});
 };
 
@@ -23,5 +24,15 @@ export const useGetPopoverAllowedServiceList = () => {
 	return useQuery({
 		queryKey: timerKeys.popover(),
 		queryFn: getPopoverAllowedServiceList,
+	});
+};
+
+export const useGetUpdateTimerInfo = ({ taskId, elapsedTime, targetDate, timerStatus }: GetUpdateTimerInfoReq) => {
+	return useQuery({
+		queryKey: timerKeys.updateTimerInfo({ taskId, elapsedTime, targetDate, timerStatus }),
+		queryFn: () => getUpdateTimerInfo({ taskId, elapsedTime, targetDate, timerStatus }),
+		refetchInterval: 40000,
+		refetchIntervalInBackground: true,
+		enabled: !!taskId,
 	});
 };

--- a/src/shared/types/api/timer.ts
+++ b/src/shared/types/api/timer.ts
@@ -61,3 +61,10 @@ export interface PostUpdateTimerInfoReq {
 	targetDate: string;
 	timerStatus: 'RUNNING' | 'PAUSED';
 }
+
+export interface GetUpdateTimerInfoReq {
+	taskId: number;
+	elapsedTime: number;
+	targetDate: string;
+	timerStatus: 'RUNNING' | 'PAUSED';
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 타이머 정보를 업데이트하는 polling 함수 생성 - 40초
- [x] heartbeat polling 함수 interval 수정 - 30초
- [x] 타이머 하단 친구 정보 조회 interval 설정 - 58초

## 🔧 작업 내용

#### polling interval을 변경해주었어요.
  - QA 때 주기를 1초로 설정했더니 서버에서 polling을 처리하는데 부하가 있어, api 요청이 pending 되는 이슈가 있었어요
  - 그래서 polling 주기를 heartbeat 30초를 기준으로 각각 다르게 설정하여 다시 테스트를 해보기로했어요
    - 3개의 polling 함수의 주기를 모두 다르게 했어요. 주기가 겹치면 부하가 있을거라고 생각했어요.
    - 우리가 친구목록에서 보여주고자 하는 실시간 데이터는 분단위의 친구 시간이에요. 그래서 친구 정보 조회의 폴링 주기를 58초로 설정했어요(api 요청 지연 고려하여 2초를 임의로 빼주었어요)
    
 #### 타이머 정보를 업데이트 하는 polling 함수 생성했어요
 - 기존 타이머의 정보를 실시간으로 보내는 함수는 post 함수에요. 이 함수를 useEffect와 setInterval을 설정하여 실행해주고 있었어요.
      - 이 폴링 훅의 useEffect 의존성 배열에 1초마다 변하는 타이머 시간 상태를 넣어주었는데, 이 때문에 계속해서 useEffect가 재실행되어 클린업 함수에서 clearInterval이 동작해 polling이 제대로 동작하지 않는 이슈가 있었어요
      - 의존성 배열을 비워주면 되는 문제이지만, 관리에 불편함을 느꼈고, post를 get으로 변경하여 useQuery의 refetchInterval을 이용하는게 유지보수에 좋다고 생각했어요. 그래서 서버와 협의 후에 get과 queyString을 이용하여 타이머의 정보를 업데이트 해주는 polling 함수를 새로 만들었어요.

#### 타이머 하단 친구 정보 조회 interval 재설정

>  우리가 친구목록에서 보여주고자 하는 실시간 성은 분단위의 친구 시간이에요. 그래서 친구 정보 조회의 폴링 주기를 58초로 설정했어요(api 요청 지연 고려하여 2초를 임의로 빼주었어요)


## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
