### PR TITLE
[ QA ] home페이지 3차 QA 반영합니다.

### DIFF
--- a/src/pages/HomePage/BoxCategory/BoxCategory.tsx
+++ b/src/pages/HomePage/BoxCategory/BoxCategory.tsx
@@ -58,7 +58,6 @@ const BoxCategory = ({
 	addingComplete,
 	onDeleteCategory,
 	onPatchCategory,
-	isSelectedTodoExist,
 	selectedDate,
 }: BoxCategoryProps) => {
 	const { mutate, isError, error } = usePostCreateTask();
@@ -253,7 +252,7 @@ const BoxCategory = ({
 						<Dropdown.Trigger>
 							<MeatballDefaultIcon className="rounded-full hover:bg-gray-bg-04 active:bg-gray-bg-05" />
 						</Dropdown.Trigger>
-						<Dropdown.Content className="top-[3.2rem]">
+						<Dropdown.Content className="right-0 top-[3.2rem]">
 							<Dropdown.Item label="카테고리 이름 수정" onClick={handleStartEditing} />
 							<Dropdown.Item label="카테고리 삭제" textColor="red" onClick={() => onDeleteCategory(id)} />
 						</Dropdown.Content>
@@ -352,7 +351,6 @@ const BoxCategory = ({
 										updateTodayTodos={() => updateTodayTodos(todo)}
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
-										isSelectedTodoExist={isSelectedTodoExist}
 										handleCalendarToggle={() => handleOpenTaskCalendar(id)}
 										onPatchTask={handlePatchTask}
 									/>
@@ -376,7 +374,6 @@ const BoxCategory = ({
 										}}
 										clickable={addingTodayTodoStatus}
 										addingComplete={addingComplete}
-										isSelectedTodoExist={isSelectedTodoExist}
 										handleCalendarToggle={() => handleOpenTaskCalendar(id)}
 									/>
 								))}

--- a/src/pages/HomePage/BoxTodayTodo/StatusDefaultBoxTodayTodo/StatusDefaultBoxTodayTodo.tsx
+++ b/src/pages/HomePage/BoxTodayTodo/StatusDefaultBoxTodayTodo/StatusDefaultBoxTodayTodo.tsx
@@ -13,7 +13,8 @@ const StatusDefaultBoxTodayTodo = ({ hasTodos, onEnableAddStatus }: StatusDefaul
 				<p className="text-center text-gray-03 body-med-16">아직 오늘 할 일이 없어요</p>
 				<p className="mb-[2.2rem] mt-[1.2rem] text-center text-gray-05 subhead-semibold-18">
 					할 일을 추가하려면
-					<br />+ 아이콘을 선택해주세요.
+					<br />
+					아래 버튼을 선택해주세요.
 				</p>
 				<div className="mx-auto">
 					<ButtonRadius8.Md disabled={!hasTodos} onClick={onEnableAddStatus}>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -207,10 +207,6 @@ const HomePage = () => {
 
 	useEffect(() => {
 		setTodayTodos(todayTodosStorageData);
-
-		if (todayTodosStorageData.length > 0) {
-			setAddingTodayTodoStatus(true);
-		}
 	}, [todayTodosStorageData]);
 
 	useEffect(() => {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -206,10 +206,6 @@ const HomePage = () => {
 	};
 
 	useEffect(() => {
-		setTodayTodos(todayTodosStorageData);
-	}, [todayTodosStorageData]);
-
-	useEffect(() => {
 		handleCategoryScroll();
 	}, [isAddingCategory, dailyCategoryTask.length]);
 

--- a/src/pages/OnboardingPage/StepStart/StepStart.tsx
+++ b/src/pages/OnboardingPage/StepStart/StepStart.tsx
@@ -16,7 +16,7 @@ const StepStart = ({ setStep }: StepStartProps) => {
 			<h1 className="mb-[2rem] text-center text-white title-bold-36">
 				집중을 도와줄 허용서비스 리스트를 만들어볼까요?
 			</h1>
-			<p className="body-med-24 mb-[8.3rem] text-center text-gray-04">
+			<p className="mb-[8.3rem] text-center text-gray-04 body-med-24">
 				작업 할 때 필요한 서비스들만을 사용하며 오롯이 할 일에 집중해보세요.
 				<br />
 				작업할 때 자주 쓰는 서비스들을 추천해드릴게요!

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -31,7 +31,6 @@ interface BoxTodoProps {
 	clickable?: boolean;
 	addingComplete?: boolean;
 	timerIncreasedTime?: number;
-	isSelectedTodoExist?: boolean;
 	handleCalendarToggle?: () => void;
 	onPatchTask?: (taskId: number, name: string, startDate: string, endDate: string | null) => void;
 }
@@ -51,7 +50,6 @@ const BoxTodo = ({
 	elapsedTime,
 	addingComplete,
 	timerIncreasedTime,
-	isSelectedTodoExist,
 	handleCalendarToggle,
 	onPatchTask,
 }: BoxTodoProps) => {
@@ -142,7 +140,7 @@ const BoxTodo = ({
 							</h3>
 						)}
 					</div>
-					{!isSelectedTodoExist && !addingComplete && (
+					{!addingComplete && !isSelected && (
 						<Dropdown>
 							<Dropdown.Trigger>
 								<MeatballIcon className="opacity-0 transition-opacity duration-300 group-hover:opacity-100" />

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -161,7 +161,7 @@ const BoxTodo = ({
 				<div className="ml-[0.8rem] mt-[0.7rem] flex flex-col gap-[0.2rem]">
 					<button
 						className={`flex items-center gap-[0.6rem] ${!addingComplete ? 'pointer-events-none' : ''}`}
-						onClick={!addingComplete && !isSelected ? handleCalendarToggle : undefined}
+						onClick={handleCalendarToggle}
 					>
 						<ButtonCalendarIcon />
 						<p className="mt-[0.3rem] text-gray-04 detail-reg-12">{duration}</p>

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -159,7 +159,10 @@ const BoxTodo = ({
 					)}
 				</div>
 				<div className="ml-[0.8rem] mt-[0.7rem] flex flex-col gap-[0.2rem]">
-					<button className="flex items-center gap-[0.6rem]" onClick={handleCalendarToggle}>
+					<button
+						className={`flex items-center gap-[0.6rem] ${!addingComplete ? 'pointer-events-none' : ''}`}
+						onClick={!addingComplete && !isSelected ? handleCalendarToggle : undefined}
+					>
 						<ButtonCalendarIcon />
 						<p className="mt-[0.3rem] text-gray-04 detail-reg-12">{duration}</p>
 					</button>


### PR DESCRIPTION

## 🔥 Related Issues

## ✅ 작업 리스트

- [x] home 3차 qa 반영


## 🔧 작업 내용
> 1. 계정 로그아웃하고 다시 로그인했을 시 로컬스토리지에 남아있는 할일이 오른쪽 타이머 할일 목록에 선택되어있는 이슈

-> home에 useEffect 내에서 todayTodosStorageData의 길이가 0보다 클 때 자동으로 addingTodayTodoStatus를 true로 설정하도록 되어있는 부분 삭제했습니다!


> 2. 타이머 추가/수정할 때 더보기 버튼이나 캘린더 선택 안되도록 반영

https://github.com/user-attachments/assets/be103170-6339-48ac-b8e3-060e7045663c

-> 타이머 추가/수정 모드일 때 캘린더 클릭 이벤트를 비활성화시키고 더보기 버튼이 안 뜨도록 수정했습니다!

> 3. 할일카드 ‘+아이콘->아래 버튼’으로 문구 변경

<img width="182" alt="스크린샷 2025-04-04 오후 2 33 08" src="https://github.com/user-attachments/assets/96eed48a-395e-4c87-b13d-6a5373cc3d00" />

> 4. 홈 카테고리 수정 시 드롭다운 위치 안쪽으로 조정

<img width="254" alt="스크린샷 2025-04-04 오후 2 34 15" src="https://github.com/user-attachments/assets/ed00d35f-b351-455e-82d5-acaf8a168e9e" />



## 🤔 궁금한 점

