### PR TITLE
[ QA ] Polling 로직을 변경합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
     "workerDirectory": [
       "public"
     ]
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,5 @@
     "workerDirectory": [
       "public"
     ]
-  },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  }
 }

--- a/src/pages/HomePage/BoxTodayTodo/StatusAddBoxTodayTodo/StatusAddBoxTodayTodo.tsx
+++ b/src/pages/HomePage/BoxTodayTodo/StatusAddBoxTodayTodo/StatusAddBoxTodayTodo.tsx
@@ -1,5 +1,3 @@
-import { useSetAtom } from 'jotai';
-
 import BoxTodo from '@/shared/components/BoxTodo/BoxTodo';
 import ButtonRadius5 from '@/shared/components/ButtonRadius5/ButtonRadius5';
 import Spacer from '@/shared/components/Spacer/Spacer';
@@ -7,8 +5,6 @@ import Spacer from '@/shared/components/Spacer/Spacer';
 import type { TaskType } from '@/shared/types/tasks';
 
 import { LARGE_BTN_TEXT, SMALL_BTN_TEXT } from '@/shared/constants/btnText';
-
-import { todayTodoAtom } from '@/shared/stores/atoms/todayTodoAtom';
 
 interface StatusAddBoxTodayTodoProps {
 	selectedTodayTodos: Omit<TaskType, 'isComplete'>[];
@@ -31,8 +27,6 @@ const StatusAddBoxTodayTodo = ({
 	addingComplete,
 	onCreateTodayTodos,
 }: StatusAddBoxTodayTodoProps) => {
-	const dispatchTodayTodos = useSetAtom(todayTodoAtom);
-
 	const hasTodayTodos = !(selectedTodayTodos.length === 0);
 	const clickable = addingComplete ? '' : 'pointer-events-none cursor-default ';
 	const handleMouseEnter = () => {
@@ -42,12 +36,10 @@ const StatusAddBoxTodayTodo = ({
 	};
 
 	const handleCancelComplete = () => {
-		dispatchTodayTodos([]);
 		onDisableAddStatus();
 	};
 
 	const handleStartTimer = () => {
-		dispatchTodayTodos(selectedTodayTodos);
 		onCreateTodayTodos();
 	};
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,7 +1,6 @@
 import dayjs, { Dayjs } from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import { useAtomValue } from 'jotai';
 
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -31,7 +30,6 @@ import {
 	usePostAddTodayTodos,
 } from '@/shared/apisV2/home/home.mutations';
 import { useGetCategoryTask, useGetWorkTime } from '@/shared/apisV2/home/home.queries';
-import { todayTodoAtom } from '@/shared/stores/atoms/todayTodoAtom';
 
 import BoxAddCategory from './BoxAddCategory/BoxAddCategory';
 import BoxCategory from './BoxCategory/BoxCategory';
@@ -69,7 +67,6 @@ const HomePage = () => {
 	// NOTE: 추후 사용 예정
 	// const addTodayTodosOverlayStyle = addingTodayTodoStatus && !addingComplete ? 'opacity-30 pointer-events-none' : '';
 
-	const todayTodosStorageData = useAtomValue(todayTodoAtom);
 	const [todayTodos, setTodayTodos] = useState<Omit<TaskType, 'isComplete'>[]>([]);
 	const [categoryInput, setCategoryInput] = useState('');
 

--- a/src/pages/TimerPage/TimerPage.tsx
+++ b/src/pages/TimerPage/TimerPage.tsx
@@ -18,11 +18,7 @@ import HomeIcon from '@/shared/assets/svgs/btn_home.svg?react';
 import { ROUTES_CONFIG } from '@/router/routesConfig';
 
 import { usePostUpdateTimerInfo } from '@/shared/apisV2/timer/timer.mutations';
-import {
-	useGetPopoverAllowedServiceList,
-	useGetTimerTodos,
-	useGetUpdateTimerInfo,
-} from '@/shared/apisV2/timer/timer.queries';
+import { useGetPopoverAllowedServiceList, useGetTimerTodos } from '@/shared/apisV2/timer/timer.queries';
 
 import Carousel from './Carousel/Carousel';
 import PopoverAllowedService from './PopoverAllowedService/PopoverAllowedService';
@@ -58,17 +54,26 @@ const TimerPage = () => {
 
 	const { data: allowedServiceList } = useGetPopoverAllowedServiceList();
 	const { isSidebarOpen, handleSidebarToggle } = useToggleSidebar();
+	const { mutate: updateTimerInfo } = usePostUpdateTimerInfo();
+
+	const handleUpdateTimerInfo = () => {
+		updateTimerInfo({
+			taskId: selectedTodoId!,
+			elapsedTime: timerTime,
+			targetDate: formattedTodayDate,
+			timerStatus: isPlaying ? 'RUNNING' : 'PAUSED',
+		});
+	};
+
 	const {
 		timer: timerTime,
 		increasedTime: timerIncreasedTime,
 		resetIncreasedTime: resetTimerIncreasedTime,
-	} = useTimerCount({ isPlaying, previousTime: elapsedTime });
+	} = useTimerCount({ isPlaying, previousTime: elapsedTime, callback: handleUpdateTimerInfo });
 	const { timer: accumulatedTime, resetIncreasedTime: resetAccumulatedIncreasedTime } = useTimerCount({
 		isPlaying,
 		previousTime: totalTimeOfToday,
 	});
-
-	const { mutate: updateTimerInfo } = usePostUpdateTimerInfo();
 
 	const urls = useMemo(() => allowedSitesUrl.map((url) => url.trim()) || [], [allowedSitesUrl]);
 
@@ -151,13 +156,6 @@ const TimerPage = () => {
 			setAllowedSitesUrl(uniqueAllowedSites);
 		}
 	}, [allowedServiceList]);
-
-	useGetUpdateTimerInfo({
-		taskId: selectedTodoId!,
-		elapsedTime: timerIncreasedTime,
-		targetDate: formattedTodayDate,
-		timerStatus: isPlaying ? 'RUNNING' : 'PAUSED',
-	});
 
 	return (
 		<div className="fixed">

--- a/src/pages/TimerPage/hooks/useTimerCount.ts
+++ b/src/pages/TimerPage/hooks/useTimerCount.ts
@@ -15,6 +15,7 @@ interface UseTimerCountReturn {
 export const useTimerCount = ({ isPlaying, previousTime, callback }: UseTimerCountProps): UseTimerCountReturn => {
 	const [increasedTime, setIncreasedTime] = useState(0);
 	const timerIntervalId = useRef<ReturnType<typeof setInterval> | null>(null);
+	const lastMilestoneRef = useRef<number | null>(null);
 
 	useEffect(() => {
 		setIncreasedTime(0);
@@ -24,8 +25,12 @@ export const useTimerCount = ({ isPlaying, previousTime, callback }: UseTimerCou
 		if (isPlaying) {
 			if (timerIntervalId.current === null) {
 				timerIntervalId.current = setInterval(() => {
-					if ((previousTime + increasedTime) % 40 === 0) {
+					const totalTime = previousTime + increasedTime;
+					const currentMilestone = Math.floor(totalTime / 40);
+
+					if ((previousTime + increasedTime) % 40 === 0 && currentMilestone !== lastMilestoneRef.current) {
 						callback?.();
+						lastMilestoneRef.current = currentMilestone;
 					}
 					setIncreasedTime((prevTime) => prevTime + 1);
 				}, 1000);

--- a/src/pages/TimerPage/hooks/useTimerCount.ts
+++ b/src/pages/TimerPage/hooks/useTimerCount.ts
@@ -28,7 +28,7 @@ export const useTimerCount = ({ isPlaying, previousTime, callback }: UseTimerCou
 					const totalTime = previousTime + increasedTime;
 					const currentMilestone = Math.floor(totalTime / 40);
 
-					if ((previousTime + increasedTime) % 40 === 0 && currentMilestone !== lastMilestoneRef.current) {
+					if (totalTime % 40 === 0 && currentMilestone !== lastMilestoneRef.current) {
 						callback?.();
 						lastMilestoneRef.current = currentMilestone;
 					}

--- a/src/pages/TimerPage/hooks/useTimerCount.ts
+++ b/src/pages/TimerPage/hooks/useTimerCount.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 interface UseTimerCountProps {
 	isPlaying: boolean;
 	previousTime: number;
+	callback?: () => void;
 }
 
 interface UseTimerCountReturn {
@@ -11,7 +12,7 @@ interface UseTimerCountReturn {
 	resetIncreasedTime: () => void;
 }
 
-export const useTimerCount = ({ isPlaying, previousTime }: UseTimerCountProps): UseTimerCountReturn => {
+export const useTimerCount = ({ isPlaying, previousTime, callback }: UseTimerCountProps): UseTimerCountReturn => {
 	const [increasedTime, setIncreasedTime] = useState(0);
 	const timerIntervalId = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -23,6 +24,9 @@ export const useTimerCount = ({ isPlaying, previousTime }: UseTimerCountProps): 
 		if (isPlaying) {
 			if (timerIntervalId.current === null) {
 				timerIntervalId.current = setInterval(() => {
+					if ((previousTime + increasedTime) % 40 === 0) {
+						callback?.();
+					}
 					setIncreasedTime((prevTime) => prevTime + 1);
 				}, 1000);
 			}

--- a/src/shared/apisV2/timer/timer.queries.ts
+++ b/src/shared/apisV2/timer/timer.queries.ts
@@ -27,7 +27,7 @@ export const useGetPopoverAllowedServiceList = () => {
 	});
 };
 
-export const useGetUpdateTimerInfo = ({ taskId, elapsedTime, targetDate, timerStatus }: GetUpdateTimerInfoReq) => {
+export const useGetUpdateTimerInfoPing = ({ taskId, elapsedTime, targetDate, timerStatus }: GetUpdateTimerInfoReq) => {
 	return useQuery({
 		queryKey: timerKeys.updateTimerInfo({ taskId, elapsedTime, targetDate, timerStatus }),
 		queryFn: () => getUpdateTimerInfo({ taskId, elapsedTime, targetDate, timerStatus }),

--- a/src/shared/stores/atoms/todayTodoAtom.ts
+++ b/src/shared/stores/atoms/todayTodoAtom.ts
@@ -1,5 +1,0 @@
-import { atomWithStorage } from 'jotai/utils';
-
-import { TaskType } from '@/shared/types/tasks';
-
-export const todayTodoAtom = atomWithStorage<Omit<TaskType, 'isComplete'>[]>('todayTodos', []);


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] Polling 로직 변경
- [x] 오늘 할일 저장하는 atom 및 로직 삭제

## 🔧 작업 내용

####  polling 로직 변경
- 타이머는 setInterval을 통해 초단위로 리렌더링이 되고있어요. 초가 흐름에 따라서 시간 상태가 변경되기 떄문이에요. 이 때문에 Polling 시간을 설정해도 계속 1초마다 함수가 실행되는 이슈가 있었어요. 그래서 타이머 시간이 40의 배수가 되는 시점에 업데이트된 타이머의 정보를 보낼 수 있게끔 했어요

- 클라이언트에서만 타이머 시간을 관리하면 웹이 active되지 않았을 때 이슈가 많아서(또한 리렌더링 등으로 시간의 싱크가 안맞음) -> 추후에 서버에서 타이머를 관리하는 로직으로 변경해주기로했어요.
- 그럼에도 react에서 이렇게 구현해놓은 이유는 electron에서는 애플리케이션 창을 닫아놓아도(종료 X) 해당 로직이 제대로 실행될 수 있는지 테스트가 필요해서에요

#### 오늘의 할일 저장하는 atom 및 로직 삭제
이전 pr에서 반영되었던 오늘의 할일을 저장하는 로직과 아톰을 모두 삭제해주었어요

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
