### PR TITLE
[QA] 허용서비스 QA 반영, 허용 서비스 세트 추천 사이트 조회 api를 연결합니다.

### DIFF
--- a/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Content/AllowedServiceGroupDetailContent.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Content/AllowedServiceGroupDetailContent.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 
+import FaviconImage from '@/shared/components/FaviconImage/FaviconImage';
 import Spacer from '@/shared/components/Spacer/Spacer';
 
 import { AllowedServiceGroupDetailSiteType } from '@/shared/types/allowedService';
@@ -61,7 +62,7 @@ export const AllowedServiceGroupDetailContentTableRow = ({
 	return (
 		<div className="flex h-[5rem] items-center border-b-[0.1rem] border-gray-bg-04 px-[1rem]">
 			<div className="flex w-[24rem] flex-shrink-0 items-center gap-x-[0.5rem] truncate pr-[1rem] text-left text-white body-med-16">
-				<img src={allowedSiteData.favicon} alt="favicon" className="mr-[0.6rem] h-[2rem] w-[2rem]" />
+				<FaviconImage src={allowedSiteData.favicon} className="mr-[0.6rem]" />
 				<p className="truncate">{allowedSiteData.siteName}</p>
 			</div>
 			<div className="w-[31rem] flex-shrink-0 truncate pr-[1rem] text-left text-gray-04 body-reg-16">

--- a/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Content/AllowedServiceGroupDetailContent.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceGroupDetail/Content/AllowedServiceGroupDetailContent.tsx
@@ -62,7 +62,11 @@ export const AllowedServiceGroupDetailContentTableRow = ({
 	return (
 		<div className="flex h-[5rem] items-center border-b-[0.1rem] border-gray-bg-04 px-[1rem]">
 			<div className="flex w-[24rem] flex-shrink-0 items-center gap-x-[0.5rem] truncate pr-[1rem] text-left text-white body-med-16">
-				<FaviconImage src={allowedSiteData.favicon} className="mr-[0.6rem]" />
+				<FaviconImage
+					src={allowedSiteData.favicon}
+					className="mr-[0.6rem]"
+					alt={`${allowedSiteData.siteName} 아이콘`}
+				/>
 				<p className="truncate">{allowedSiteData.siteName}</p>
 			</div>
 			<div className="w-[31rem] flex-shrink-0 truncate pr-[1rem] text-left text-gray-04 body-reg-16">

--- a/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
@@ -122,7 +122,9 @@ const AllowedServiceListItem = ({
 			</Spacer.Width>
 
 			<div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
-				{allowedServiceGroupData?.favicons.map((siteUrl) => <FaviconImage key={siteUrl} src={siteUrl} />)}
+				{allowedServiceGroupData?.favicons.map((siteUrl) => (
+					<FaviconImage key={siteUrl} src={siteUrl} className="rounded-full" />
+				))}
 				{allowedServiceGroupData?.extraCnt > 0 && (
 					<div className="body-detail-reg-12 flex h-[2rem] w-[2rem] items-center justify-center rounded-[57px] bg-date-active text-white">
 						+{allowedServiceGroupData.extraCnt}

--- a/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
@@ -1,6 +1,7 @@
 import { ButtonHTMLAttributes, MouseEvent, ReactNode } from 'react';
 
 import Dropdown from '@/shared/components/Dropdown/Dropdown';
+import FaviconImage from '@/shared/components/FaviconImage/FaviconImage';
 import Spacer from '@/shared/components/Spacer/Spacer';
 
 import { AllowedServiceGroupType, ColorPaletteType } from '@/shared/types/allowedService';
@@ -121,9 +122,7 @@ const AllowedServiceListItem = ({
 			</Spacer.Width>
 
 			<div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
-				{allowedServiceGroupData?.favicons.map((siteUrl) => (
-					<img key={siteUrl} src={siteUrl} alt="favicon" className="h-[2rem] w-[2rem] rounded-full" />
-				))}
+				{allowedServiceGroupData?.favicons.map((siteUrl) => <FaviconImage key={siteUrl} src={siteUrl} />)}
 				{allowedServiceGroupData?.extraCnt > 0 && (
 					<div className="body-detail-reg-12 flex h-[2rem] w-[2rem] items-center justify-center rounded-[57px] bg-date-active text-white">
 						+{allowedServiceGroupData.extraCnt}

--- a/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
+++ b/src/pages/AllowedServicePage/AllowedServiceList/AllowedServiceList.tsx
@@ -123,7 +123,7 @@ const AllowedServiceListItem = ({
 
 			<div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
 				{allowedServiceGroupData?.favicons.map((siteUrl) => (
-					<FaviconImage key={siteUrl} src={siteUrl} className="rounded-full" />
+					<FaviconImage key={siteUrl} src={siteUrl} className="rounded-full" alt="사이트 아이콘" />
 				))}
 				{allowedServiceGroupData?.extraCnt > 0 && (
 					<div className="body-detail-reg-12 flex h-[2rem] w-[2rem] items-center justify-center rounded-[57px] bg-date-active text-white">

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -75,7 +75,9 @@ const AllowedServicePage = () => {
 		allowedGroupId: activeGroupId!,
 		connectType: currentTap,
 	});
-	const { data: recommendedSites } = useGetRecommendedSites();
+	const { data: recommendedSites } = useGetRecommendedSites({
+		allowedGroupId: activeGroupId!,
+	});
 
 	const { mutate: patchChangeAllowedServiceGroupName } = usePatchChangeAllowedServiceGroupName();
 	const { mutate: patchChangeAllowedServiceGroupColor } = usePatchChangeAllowedServiceGroupColor();

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -43,6 +43,7 @@ const AllowedServicePage = () => {
 	const [isEditingTitle, setIsEditingTitle] = useState(false);
 	const [urlInput, setUrlInput] = useState('');
 	const [selectedColor, setSelectedColor] = useState<ColorPaletteType>('#868C93');
+	const isProcessingRef = useRef(false);
 
 	const queryClient = useQueryClient();
 
@@ -170,7 +171,8 @@ const AllowedServicePage = () => {
 	};
 
 	const handleAddAllowedService = (urlInput: string, activeGroupId: number | null) => {
-		if (activeGroupId) {
+		if (activeGroupId && !isProcessingRef.current && urlInput.trim() !== '') {
+			isProcessingRef.current = true;
 			postAddAllowedService(
 				{
 					siteUrl: urlInput,
@@ -179,6 +181,7 @@ const AllowedServicePage = () => {
 				{
 					onSuccess: () => {
 						setUrlInput('');
+						isProcessingRef.current = false;
 					},
 				},
 			);

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -160,6 +160,7 @@ const AllowedServicePage = () => {
 						(oldData: GetAllowedServiceListRes) => {
 							if (!oldData) return oldData;
 							return {
+								...oldData,
 								data: oldData.data.filter((group) => group.id !== groupId),
 							};
 						},
@@ -178,7 +179,7 @@ const AllowedServicePage = () => {
 	};
 
 	const handleAddAllowedService = (urlInput: string, activeGroupId: number | null) => {
-		if (activeGroupId && !isPending && urlInput.trim() !== '') {
+		if (activeGroupId && !isPending) {
 			postAddAllowedService(
 				{
 					siteUrl: urlInput,
@@ -315,7 +316,7 @@ const AllowedServicePage = () => {
 							>
 								<TextField.ClearButton onClick={resetUrlInput} />
 								<TextField.ConfirmButton
-									disabled={urlInput.length === 0 || isPending}
+									disabled={urlInput.trim().length === 0 || isPending}
 									onClick={() => handleAddAllowedService(urlInput, activeGroupId)}
 								>
 									사이트 등록하기

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -43,7 +43,6 @@ const AllowedServicePage = () => {
 	const [isEditingTitle, setIsEditingTitle] = useState(false);
 	const [urlInput, setUrlInput] = useState('');
 	const [selectedColor, setSelectedColor] = useState<ColorPaletteType>('#868C93');
-	const isProcessingRef = useRef(false);
 
 	const queryClient = useQueryClient();
 
@@ -83,7 +82,13 @@ const AllowedServicePage = () => {
 	const { mutate: patchChangeAllowedServiceGroupColor } = usePatchChangeAllowedServiceGroupColor();
 	const { mutate: postAddAllowedServiceGroup } = usePostAddAllowedServiceGroup();
 	const { mutate: deleteAllowedServiceGroup } = useDeleteAllowedServiceGroup();
-	const { mutate: postAddAllowedService, reset: resetAllowedService, isError, error } = usePostAddAllowedService();
+	const {
+		mutate: postAddAllowedService,
+		reset: resetAllowedService,
+		isPending,
+		isError,
+		error,
+	} = usePostAddAllowedService();
 	const { mutate: deleteAllowedService } = useDeleteAllowedService();
 
 	const resetUrlInput = () => {
@@ -173,8 +178,7 @@ const AllowedServicePage = () => {
 	};
 
 	const handleAddAllowedService = (urlInput: string, activeGroupId: number | null) => {
-		if (activeGroupId && !isProcessingRef.current && urlInput.trim() !== '') {
-			isProcessingRef.current = true;
+		if (activeGroupId && !isPending && urlInput.trim() !== '') {
 			postAddAllowedService(
 				{
 					siteUrl: urlInput,
@@ -183,10 +187,6 @@ const AllowedServicePage = () => {
 				{
 					onSuccess: () => {
 						setUrlInput('');
-						isProcessingRef.current = false;
-					},
-					onError: () => {
-						isProcessingRef.current = false;
 					},
 				},
 			);
@@ -315,7 +315,7 @@ const AllowedServicePage = () => {
 							>
 								<TextField.ClearButton onClick={resetUrlInput} />
 								<TextField.ConfirmButton
-									disabled={urlInput.length === 0 && isProcessingRef.current}
+									disabled={urlInput.length === 0 && isPending}
 									onClick={() => handleAddAllowedService(urlInput, activeGroupId)}
 								>
 									사이트 등록하기

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -152,7 +152,6 @@ const AllowedServicePage = () => {
 						(oldData: GetAllowedServiceListRes) => {
 							if (!oldData) return oldData;
 							return {
-								...oldData,
 								data: oldData.data.filter((group) => group.id !== groupId),
 							};
 						},

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -315,7 +315,7 @@ const AllowedServicePage = () => {
 							>
 								<TextField.ClearButton onClick={resetUrlInput} />
 								<TextField.ConfirmButton
-									disabled={urlInput.length === 0}
+									disabled={urlInput.length === 0 && isProcessingRef.current}
 									onClick={() => handleAddAllowedService(urlInput, activeGroupId)}
 								>
 									사이트 등록하기

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -185,6 +185,9 @@ const AllowedServicePage = () => {
 						setUrlInput('');
 						isProcessingRef.current = false;
 					},
+					onError: () => {
+						isProcessingRef.current = false;
+					},
 				},
 			);
 		}

--- a/src/pages/AllowedServicePage/AllowedServicePage.tsx
+++ b/src/pages/AllowedServicePage/AllowedServicePage.tsx
@@ -315,7 +315,7 @@ const AllowedServicePage = () => {
 							>
 								<TextField.ClearButton onClick={resetUrlInput} />
 								<TextField.ConfirmButton
-									disabled={urlInput.length === 0 && isPending}
+									disabled={urlInput.length === 0 || isPending}
 									onClick={() => handleAddAllowedService(urlInput, activeGroupId)}
 								>
 									사이트 등록하기

--- a/src/shared/apisV2/allowedService/allowedService.api.ts
+++ b/src/shared/apisV2/allowedService/allowedService.api.ts
@@ -5,6 +5,7 @@ import {
 	GetAllowedServiceGroupDetailRes,
 	GetAllowedServiceListReq,
 	GetAllowedServiceListRes,
+	GetRecommendedSitesReq,
 	GetRecommendedSitesRes,
 	PatchChangeAllowedServiceGroupColorReq,
 	PatchChangeAllowedServiceGroupNameReq,
@@ -21,7 +22,7 @@ const ALLOWED_SERVICE_ENDPOINT = {
 	PATCH_CHANGE_ALLOWED_SERVICE_GROUP_NAME: 'api/v2/allowedGroup/:allowedGroupId/name',
 	PATCH_CHANGE_ALLOWED_SERVICE_GROUP_COLOR: 'api/v2/allowedGroup/:allowedGroupId/colorCode',
 	DELETE_ALLOWED_SERVICE_GROUP: 'api/v2/allowedGroup/:allowedGroupId',
-	GET_RECOMMENDED_STIES: 'api/v2/recommendSite',
+	GET_RECOMMENDED_SITES: 'api/v2/recommendSite',
 	POST_ADD_ALLOWED_SERVICE: 'api/v2/allowedSite/:allowedGroupId',
 	DELETE_ALLOWED_SERVICE: 'api/v2/allowedSite/:allowedSiteId',
 };
@@ -81,8 +82,10 @@ export const deleteAllowedServiceGroup = async ({ allowedGroupId }: DeleteAllowe
 	return data;
 };
 
-export const getRecommendedSites = async (): Promise<GetRecommendedSitesRes> => {
-	const { data } = await authClient.get(ALLOWED_SERVICE_ENDPOINT.GET_RECOMMENDED_STIES);
+export const getRecommendedSites = async ({
+	allowedGroupId,
+}: GetRecommendedSitesReq): Promise<GetRecommendedSitesRes> => {
+	const { data } = await authClient.get(ALLOWED_SERVICE_ENDPOINT.GET_RECOMMENDED_SITES, { params: { allowedGroupId } });
 	return data;
 };
 

--- a/src/shared/apisV2/allowedService/allowedService.keys.ts
+++ b/src/shared/apisV2/allowedService/allowedService.keys.ts
@@ -1,4 +1,8 @@
-import { GetAllowedServiceGroupDetailReq, GetAllowedServiceListReq } from '@/shared/types/api/allowedService';
+import {
+	GetAllowedServiceGroupDetailReq,
+	GetAllowedServiceListReq,
+	GetRecommendedSitesReq,
+} from '@/shared/types/api/allowedService';
 
 export const allowedServiceKeys = {
 	allowedService: ['allowedService'] as const,
@@ -6,5 +10,6 @@ export const allowedServiceKeys = {
 		[...allowedServiceKeys.allowedService, 'list', connectType] as const,
 	allowedServiceGroupDetail: ({ allowedGroupId, connectType }: GetAllowedServiceGroupDetailReq) =>
 		[...allowedServiceKeys.allowedService, 'group', allowedGroupId, connectType] as const,
-	recommendedSites: () => [...allowedServiceKeys.allowedService, 'recommendedSites'] as const,
+	recommendedSites: ({ allowedGroupId }: GetRecommendedSitesReq) =>
+		[...allowedServiceKeys.allowedService, 'recommendedSites', allowedGroupId] as const,
 };

--- a/src/shared/apisV2/allowedService/allowedService.queries.ts
+++ b/src/shared/apisV2/allowedService/allowedService.queries.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { GetAllowedServiceGroupDetailReq, GetAllowedServiceListReq } from '@/shared/types/api/allowedService';
+import {
+	GetAllowedServiceGroupDetailReq,
+	GetAllowedServiceListReq,
+	GetRecommendedSitesReq,
+} from '@/shared/types/api/allowedService';
 
 import { getAllowedServiceGroupDetail, getAllowedServiceList, getRecommendedSites } from './allowedService.api';
 import { allowedServiceKeys } from './allowedService.keys';
@@ -20,9 +24,9 @@ export const useGetAllowedServiceGroupDetail = ({ allowedGroupId, connectType }:
 	});
 };
 
-export const useGetRecommendedSites = () => {
+export const useGetRecommendedSites = ({ allowedGroupId }: GetRecommendedSitesReq) => {
 	return useQuery({
-		queryKey: allowedServiceKeys.recommendedSites(),
-		queryFn: getRecommendedSites,
+		queryKey: allowedServiceKeys.recommendedSites({ allowedGroupId }),
+		queryFn: () => getRecommendedSites({ allowedGroupId }),
 	});
 };

--- a/src/shared/components/FaviconImage/FaviconImage.tsx
+++ b/src/shared/components/FaviconImage/FaviconImage.tsx
@@ -2,13 +2,12 @@ import { ImgHTMLAttributes } from 'react';
 
 import LogoPath from '@/shared/assets/svgs/logo_icon.svg';
 
-export const FaviconImage = ({ src, className = '', alt, ...rest }: ImgHTMLAttributes<HTMLImageElement>) => {
+export const FaviconImage = ({ src, className, ...rest }: ImgHTMLAttributes<HTMLImageElement>) => {
 	return (
 		<img
 			{...rest}
-			src={src}
+			src={src || LogoPath}
 			className={`h-[2rem] w-[2rem] ${className}`}
-			alt={alt}
 			onError={(e) => {
 				e.currentTarget.src = LogoPath;
 				e.currentTarget.alt = '모립 로고 아이콘';

--- a/src/shared/components/FaviconImage/FaviconImage.tsx
+++ b/src/shared/components/FaviconImage/FaviconImage.tsx
@@ -1,28 +1,20 @@
-import { useState } from 'react';
+import { ImgHTMLAttributes } from 'react';
 
-import LogoIcon from '@/shared/assets/svgs/logo_icon.svg?react';
+import LogoPath from '@/shared/assets/svgs/logo_icon.svg';
 
-interface FaviconImageProps {
-	src: string;
-	className?: string;
-	size?: string;
-	alt?: string;
-}
-
-export const FaviconImage = ({ src, className = '', size = '2rem', alt = '사이트 파비콘' }: FaviconImageProps) => {
-	const [imgError, setImgError] = useState(false);
-
-	const handleImageError = () => {
-		setImgError(true);
-	};
-
-	const defaultStyle = `h-[${size}] w-[${size}] ${className} `;
-
-	if (!src || imgError) {
-		return <LogoIcon className={defaultStyle} role="img" aria-label="모립 로고 아이콘" />;
-	}
-
-	return <img src={src} alt={alt} className={defaultStyle} onError={handleImageError} />;
+export const FaviconImage = ({ src, className = '', alt, ...rest }: ImgHTMLAttributes<HTMLImageElement>) => {
+	return (
+		<img
+			{...rest}
+			src={src}
+			className={`h-[2rem] w-[2rem] ${className}`}
+			alt={alt}
+			onError={(e) => {
+				e.currentTarget.src = LogoPath;
+				e.currentTarget.alt = '모립 로고 아이콘';
+			}}
+		/>
+	);
 };
 
 export default FaviconImage;

--- a/src/shared/components/FaviconImage/FaviconImage.tsx
+++ b/src/shared/components/FaviconImage/FaviconImage.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+import LogoIcon from '@/shared/assets/svgs/logo_icon.svg?react';
+
+interface FaviconImageProps {
+	src: string;
+	className?: string;
+	size?: string;
+	alt?: string;
+}
+
+export const FaviconImage = ({ src, className = '', size = '2rem', alt = 'favicon' }: FaviconImageProps) => {
+	const [imgError, setImgError] = useState(false);
+
+	const handleImageError = () => {
+		setImgError(true);
+	};
+
+	const defaultStyle = `h-[${size}] w-[${size}] rounded-full ${className}`;
+
+	if (!src || imgError) {
+		return <LogoIcon className={defaultStyle} />;
+	}
+
+	return <img src={src} alt={alt} className={defaultStyle} onError={handleImageError} />;
+};
+
+export default FaviconImage;

--- a/src/shared/components/FaviconImage/FaviconImage.tsx
+++ b/src/shared/components/FaviconImage/FaviconImage.tsx
@@ -16,7 +16,7 @@ export const FaviconImage = ({ src, className = '', size = '2rem', alt = 'favico
 		setImgError(true);
 	};
 
-	const defaultStyle = `h-[${size}] w-[${size}] rounded-full ${className}`;
+	const defaultStyle = `h-[${size}] w-[${size}] ${className}`;
 
 	if (!src || imgError) {
 		return <LogoIcon className={defaultStyle} />;

--- a/src/shared/components/FaviconImage/FaviconImage.tsx
+++ b/src/shared/components/FaviconImage/FaviconImage.tsx
@@ -9,17 +9,17 @@ interface FaviconImageProps {
 	alt?: string;
 }
 
-export const FaviconImage = ({ src, className = '', size = '2rem', alt = 'favicon' }: FaviconImageProps) => {
+export const FaviconImage = ({ src, className = '', size = '2rem', alt = '사이트 파비콘' }: FaviconImageProps) => {
 	const [imgError, setImgError] = useState(false);
 
 	const handleImageError = () => {
 		setImgError(true);
 	};
 
-	const defaultStyle = `h-[${size}] w-[${size}] ${className}`;
+	const defaultStyle = `h-[${size}] w-[${size}] ${className} `;
 
 	if (!src || imgError) {
-		return <LogoIcon className={defaultStyle} />;
+		return <LogoIcon className={defaultStyle} role="img" aria-label="모립 로고 아이콘" />;
 	}
 
 	return <img src={src} alt={alt} className={defaultStyle} onError={handleImageError} />;

--- a/src/shared/types/api/allowedService.ts
+++ b/src/shared/types/api/allowedService.ts
@@ -76,3 +76,7 @@ export interface PostAddAllowedServiceReq {
 export interface DeleteAllowedServiceReq {
 	allowedSiteId: string;
 }
+
+export interface GetRecommendedSitesReq {
+	allowedGroupId: number;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close 

## ✅ 작업 리스트

- [x] 허용서비스 url Input창 오류 이후 reset 되도록 수정 
- [x] 사이트 등록 버튼 연속 호출 시 중복된 사이트 등록되는 오류 해결
- [x] 허용 서비스 세트 추천 사이트 조회 (new) api 연결 
- [x] 파비콘 이미지 로드 실패 시 모립 아이콘 적용

## 🔧 작업 내용

#### 파비콘 이미지 로드 실패 시 모립 아이콘 적용
파비콘의 이미지가 404 에러를 반환하거나 정상적인 값이 들어오지 않을 경우 모립 아이콘으로 대체하도록 했습니다.
타이머 페이지 등 허용 서비스 외에서도 해당 기능이 필요할 거라 생각해 FaviconImage라는 공통 컴포넌트를 새로 만들었습니다. 

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
#### 허용서비스 url Input창 오류 이후 reset 되도록 수정 
https://github.com/user-attachments/assets/31cc26e8-1fc9-4cc5-91d4-1d72f2a6f87b
#### 사이트 등록 버튼 연속 호출 시 중복된 사이트 등록되는 오류 해결

https://github.com/user-attachments/assets/55c7d035-6bac-4824-85e4-d9b34218abd4

ㄴ연타 중인데 커서의 미세한 떨림... 보이시나요?
#### 파비콘 이미지 로드 실패 시 모립 아이콘 적용
https://github.com/user-attachments/assets/55082fc9-29fb-4008-b375-c40eb2f59735

