### PR TITLE
[ QA ] 홈·타이머페이지 QA 반영, 친구리스트 로직을 수정합니다.

### DIFF
--- a/src/pages/HomePage/BoxTodayTodo/StatusAddBoxTodayTodo/StatusAddBoxTodayTodo.tsx
+++ b/src/pages/HomePage/BoxTodayTodo/StatusAddBoxTodayTodo/StatusAddBoxTodayTodo.tsx
@@ -1,10 +1,19 @@
+import { useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import BoxTodo from '@/shared/components/BoxTodo/BoxTodo';
 import ButtonRadius5 from '@/shared/components/ButtonRadius5/ButtonRadius5';
+import ModalWrapper, { ModalWrapperRef } from '@/shared/components/ModalWrapper/ModalWrapper';
 import Spacer from '@/shared/components/Spacer/Spacer';
 
 import type { TaskType } from '@/shared/types/tasks';
 
 import { LARGE_BTN_TEXT, SMALL_BTN_TEXT } from '@/shared/constants/btnText';
+
+import { ROUTES_CONFIG } from '@/router/routesConfig';
+
+import RegisterAllowedService from '@/pages/HomePage/ModalContentsAlert/RegisterAllowedService/RegisterAllowedService';
+import { useGetPopoverAllowedServiceList } from '@/shared/apisV2/timer/timer.queries';
 
 interface StatusAddBoxTodayTodoProps {
 	selectedTodayTodos: Omit<TaskType, 'isComplete'>[];
@@ -27,6 +36,12 @@ const StatusAddBoxTodayTodo = ({
 	addingComplete,
 	onCreateTodayTodos,
 }: StatusAddBoxTodayTodoProps) => {
+	const { data: allowedServiceList } = useGetPopoverAllowedServiceList();
+	const registerServiceModalRef = useRef<ModalWrapperRef>(null);
+	const navigate = useNavigate();
+
+	const allowedServicePath = ROUTES_CONFIG.allowedService.path;
+
 	const hasTodayTodos = !(selectedTodayTodos.length === 0);
 	const clickable = addingComplete ? '' : 'pointer-events-none cursor-default ';
 	const handleMouseEnter = () => {
@@ -40,7 +55,11 @@ const StatusAddBoxTodayTodo = ({
 	};
 
 	const handleStartTimer = () => {
-		onCreateTodayTodos();
+		if (allowedServiceList && allowedServiceList.data.length === 0) {
+			registerServiceModalRef.current?.open();
+		} else {
+			onCreateTodayTodos();
+		}
 	};
 
 	return (
@@ -102,6 +121,21 @@ const StatusAddBoxTodayTodo = ({
 					</ButtonRadius5.Sm>
 				</div>
 			</span>
+
+			<ModalWrapper ref={registerServiceModalRef} backdrop>
+				{() => (
+					<RegisterAllowedService
+						onCloseModal={() => {
+							registerServiceModalRef.current?.close();
+							onCreateTodayTodos();
+						}}
+						onConfirm={() => {
+							registerServiceModalRef.current?.close();
+							navigate(allowedServicePath);
+						}}
+					/>
+				)}
+			</ModalWrapper>
 		</Spacer.Height>
 	);
 };

--- a/src/pages/HomePage/ButtonMoreFriends/ButtonMoreFriends.tsx
+++ b/src/pages/HomePage/ButtonMoreFriends/ButtonMoreFriends.tsx
@@ -9,8 +9,8 @@ interface ButtonMoreFriendsProps extends ButtonHTMLAttributes<HTMLButtonElement>
 const ButtonMoreFriends = ({ friendsCount, ...props }: ButtonMoreFriendsProps) => {
 	return (
 		<button className="relative mb-[2rem] h-[5.4rem]" {...props}>
-			<ButtonMoreFriendIcon className="absolute top-0 h-[5rem] w-[5rem] rounded-full hover:bg-gray-bg-04 2xl:h-[6rem] 2xl:w-[6rem]" />
-			<p className="absolute left-[1.2rem] top-[1.7rem] z-10 text-gray-04 body-med-16 2xl:left-[1.4rem] 2xl:top-[2.1rem] 2xl:subhead-med-18">
+			<ButtonMoreFriendIcon className="absolute top-[-0.3rem] h-[5rem] w-[5rem] rounded-full 2xl:h-[6rem] 2xl:w-[6rem]" />
+			<p className="absolute left-[1.5rem] top-[1.2rem] z-10 text-gray-04 body-med-16 2xl:left-[1.9rem] 2xl:top-[1.8rem] 2xl:subhead-med-18">
 				+{friendsCount}
 			</p>
 		</button>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -43,6 +43,7 @@ import BoxTodayTodo from './BoxTodayTodo/BoxTodayTodo';
 import ButtonMoreFriends from './ButtonMoreFriends/ButtonMoreFriends';
 import ButtonUserProfile from './ButtonUserProfile/ButtonUserProfile';
 import DatePicker from './DatePicker/DatePicker';
+import TimerRestriction from './ModalContentsAlert/TimerRestriction/TimerRestriction';
 import StatusDefaultHome from './StatusDefaultHome/StatusDefaultHome';
 
 dayjs.extend(utc);
@@ -57,6 +58,7 @@ const HomePage = () => {
 	const friendsModalRef = useRef<ModalWrapperRef>(null);
 	const notificationPanelRef = useRef<HTMLDivElement>(null);
 	const bellIconRef = useRef<HTMLButtonElement>(null);
+	const timerRestrictionModalRef = useRef<ModalWrapperRef>(null);
 
 	const [isNotificationVisible, setIsNotificationVisible] = useState(false);
 
@@ -191,6 +193,10 @@ const HomePage = () => {
 	};
 
 	const handleSelectedDateChange = (date: Dayjs) => {
+		if (addingTodayTodoStatus && !todayDate.isSame(date, 'day')) {
+			timerRestrictionModalRef.current?.open();
+			return;
+		}
 		setSelectedDate(date);
 	};
 
@@ -447,6 +453,16 @@ const HomePage = () => {
 
 			<ModalWrapper ref={friendsModalRef} backdrop={true}>
 				{({ isModalOpen }) => <ModalContentsFriends isModalOpen={isModalOpen} />}
+			</ModalWrapper>
+
+			<ModalWrapper ref={timerRestrictionModalRef} backdrop={true}>
+				{() => (
+					<TimerRestriction
+						onConfirm={() => {
+							timerRestrictionModalRef.current?.close();
+						}}
+					/>
+				)}
 			</ModalWrapper>
 
 			{isNotificationVisible && <NotificationPanel ref={notificationPanelRef} />}

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -280,7 +280,9 @@ const HomePage = () => {
 					})}
 				</ul>
 
-				<ButtonMoreFriends friendsCount={friendList.length - onlineFriends.length} />
+				{friendList.length - timerFriends.length > 0 && (
+					<ButtonMoreFriends friendsCount={friendList.length - timerFriends.length} />
+				)}
 			</div>
 
 			<div className={`absolute right-[3.2rem] top-[4rem] flex gap-[0.8rem] 2xl:top-[5.4rem]`}>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -253,35 +253,86 @@ const HomePage = () => {
 					<li>
 						<ButtonUserProfile isMyProfile imageUrl={userProfile?.data?.imageUrl} />
 					</li>
-					{timerFriends.slice(0, MAX_VISIBLE_FRIENDS).map((friend) => {
-						const timerFriend = timerFriends.find((tf) => tf.id === friend.id);
+					{onlineFriends.slice(0, MAX_VISIBLE_FRIENDS).map((friend) => {
+						const onlineFriend = timerFriends.find((of) => of.id === friend.id);
 
 						return (
 							<li key={friend.id} className="group relative">
 								<div className="transition-transform duration-300 group-hover:-translate-y-[1rem]">
-									<ButtonUserProfile isConnecting isOnline={friend.isOnline} imageUrl={friend.imageUrl} />
+									<ButtonUserProfile isConnecting isOnline={true} imageUrl={friend.imageUrl} />
 								</div>
 								<div className="absolute left-[-9.3rem] top-[8rem] z-[52] hidden transform group-hover:block">
-									{timerFriend && (
+									{onlineFriend ? (
 										<TooltipFriendInfo
 											key={friend.id}
 											id={friend.id}
-											image={timerFriend.imageUrl}
-											time={timerFriend.elapsedTime}
-											name={timerFriend.name}
-											categoryName={timerFriend.categoryName || ''}
-											isPlaying={timerFriend.timerStatus === 'RUNNING'}
-											isOnline={timerFriend.isOnline}
+											image={onlineFriend.imageUrl}
+											time={onlineFriend.elapsedTime}
+											name={onlineFriend.name}
+											categoryName={onlineFriend.categoryName || ''}
+											isPlaying={onlineFriend.timerStatus === 'RUNNING'}
+											isOnline={onlineFriend.isOnline}
+										/>
+									) : (
+										<TooltipFriendInfo
+											key={friend.id}
+											id={friend.id}
+											image={friend.imageUrl}
+											time={0}
+											name={friend.name}
+											categoryName=""
+											isPlaying={false}
+											isOnline={false}
 										/>
 									)}
 								</div>
 							</li>
 						);
 					})}
+					{onlineFriends.length < MAX_VISIBLE_FRIENDS &&
+						friendList
+							.filter((friend) => !friend.isOnline)
+							.slice(0, MAX_VISIBLE_FRIENDS - onlineFriends.length)
+							.map((friend) => {
+								const offlineFriend = timerFriends.find((of) => of.id === friend.id);
+
+								return (
+									<li key={friend.id} className="group relative">
+										<div className="transition-transform duration-300 group-hover:-translate-y-[1rem]">
+											<ButtonUserProfile isConnecting isOnline={false} imageUrl={friend.imageUrl} />
+										</div>
+										<div className="absolute left-[-9.3rem] top-[8rem] z-[52] hidden transform group-hover:block">
+											{offlineFriend ? (
+												<TooltipFriendInfo
+													key={friend.id}
+													id={friend.id}
+													image={offlineFriend.imageUrl}
+													time={offlineFriend.elapsedTime}
+													name={offlineFriend.name}
+													categoryName={offlineFriend.categoryName || ''}
+													isPlaying={offlineFriend.timerStatus === 'RUNNING'}
+													isOnline={offlineFriend.isOnline}
+												/>
+											) : (
+												<TooltipFriendInfo
+													key={friend.id}
+													id={friend.id}
+													image={friend.imageUrl}
+													time={0}
+													name={friend.name}
+													categoryName=""
+													isPlaying={false}
+													isOnline={false}
+												/>
+											)}
+										</div>
+									</li>
+								);
+							})}
 				</ul>
 
-				{friendList.length - timerFriends.length > 0 && (
-					<ButtonMoreFriends friendsCount={friendList.length - timerFriends.length} />
+				{friendList.length > MAX_VISIBLE_FRIENDS && (
+					<ButtonMoreFriends friendsCount={friendList.length - MAX_VISIBLE_FRIENDS} />
 				)}
 			</div>
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -187,6 +187,7 @@ const HomePage = () => {
 
 	const enableAddingTodayTodo = () => {
 		setAddingTodayTodoStatus(true);
+		setSelectedDate(todayDate);
 	};
 
 	const handleSelectedDateChange = (date: Dayjs) => {

--- a/src/pages/HomePage/ModalContentsAlert/ButtonAlert/ButtonAlert.tsx
+++ b/src/pages/HomePage/ModalContentsAlert/ButtonAlert/ButtonAlert.tsx
@@ -1,19 +1,22 @@
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 
 interface ButtonAlertProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-	variant?: 'primary' | 'danger';
+	variant?: 'primary' | 'danger' | 'mint';
 	children: ReactNode;
 	className?: string;
 }
 
 const ButtonAlert = ({ children, variant = 'primary', className = '', ...props }: ButtonAlertProps) => {
-	const primaryStyle = 'bg-gray-bg-06 hover:bg-gray-bg-04 active:bg-gray-bg-05';
-	const dangerStyle = 'bg-error-01 hover:bg-error-03 active:bg-error-03 active:text-gray-04';
-	const buttonStyle = variant === 'primary' ? primaryStyle : dangerStyle;
+	const primaryStyle = 'bg-gray-bg-06 hover:bg-gray-bg-04 text-white active:bg-gray-bg-05';
+	const dangerStyle = 'bg-error-01 hover:bg-error-03 active:bg-error-03 text-white active:text-gray-04';
+	const mintStyle = 'bg-mint-02 hover:bg-mint-01 active:bg-mint-03 text-black active:text-gray-01';
+
+	const buttonStyle = variant === 'primary' ? primaryStyle : variant === 'danger' ? dangerStyle : mintStyle;
+
 	return (
 		<button
 			{...props}
-			className={`w-full rounded-[5px] px-[4.8rem] py-[1rem] text-center text-white subhead-semibold-18 ${buttonStyle} ${className}`}
+			className={`w-full rounded-[5px] px-[4.8rem] py-[1rem] text-center subhead-semibold-18 ${buttonStyle} ${className}`}
 		>
 			{children}
 		</button>

--- a/src/pages/HomePage/ModalContentsAlert/RegisterAllowedService/RegisterAllowedService.tsx
+++ b/src/pages/HomePage/ModalContentsAlert/RegisterAllowedService/RegisterAllowedService.tsx
@@ -3,7 +3,7 @@ import { AlertModalProps } from '../types/index';
 
 const RegisterAllowedService = ({ onCloseModal, onConfirm }: AlertModalProps) => (
 	<div className="flex h-[20rem] w-[47.2rem] flex-col gap-[3rem] rounded-[8px] bg-gray-bg-04 p-[3rem]">
-		<div className="flex flex-col items-center gap-[0.1rem]">
+		<div className="flex flex-col items-center gap-[1rem]">
 			<p className="text-white subhead-bold-22">허용 서비스 세트를 먼저 등록해주세요.</p>
 			<p className="text-gray-05 subhead-med-18">허용 서비스를 등록하러 갈까요?</p>
 		</div>
@@ -12,7 +12,7 @@ const RegisterAllowedService = ({ onCloseModal, onConfirm }: AlertModalProps) =>
 				등록하기
 			</ButtonAlert>
 			<ButtonAlert variant="primary" onClick={onCloseModal}>
-				취소하기
+				나중에 하기
 			</ButtonAlert>
 		</div>
 	</div>

--- a/src/pages/HomePage/ModalContentsAlert/RegisterAllowedService/RegisterAllowedService.tsx
+++ b/src/pages/HomePage/ModalContentsAlert/RegisterAllowedService/RegisterAllowedService.tsx
@@ -1,0 +1,21 @@
+import ButtonAlert from '../ButtonAlert/ButtonAlert';
+import { AlertModalProps } from '../types/index';
+
+const RegisterAllowedService = ({ onCloseModal, onConfirm }: AlertModalProps) => (
+	<div className="flex h-[20rem] w-[47.2rem] flex-col gap-[3rem] rounded-[8px] bg-gray-bg-04 p-[3rem]">
+		<div className="flex flex-col items-center gap-[0.1rem]">
+			<p className="text-white subhead-bold-22">허용 서비스 세트를 먼저 등록해주세요.</p>
+			<p className="text-gray-05 subhead-med-18">허용 서비스를 등록하러 갈까요?</p>
+		</div>
+		<div className="flex gap-[1rem]">
+			<ButtonAlert variant="mint" onClick={onConfirm}>
+				등록하기
+			</ButtonAlert>
+			<ButtonAlert variant="primary" onClick={onCloseModal}>
+				취소하기
+			</ButtonAlert>
+		</div>
+	</div>
+);
+
+export default RegisterAllowedService;

--- a/src/pages/HomePage/ModalContentsAlert/TimerRestriction/TimerRestriction.tsx
+++ b/src/pages/HomePage/ModalContentsAlert/TimerRestriction/TimerRestriction.tsx
@@ -3,7 +3,10 @@ import { AlertModalProps } from '../types/index';
 
 const TimerRestriction = ({ onConfirm }: AlertModalProps) => (
 	<div className="flex h-[19.8rem] w-[47.2rem] flex-col gap-[3rem] rounded-[8px] bg-gray-bg-04 p-[3rem]">
-		<p className="text-center text-gray-05 subhead-bold-22">오늘 날짜에 해당하는 할 일만 타이머를 실행할 수 있어요.</p>
+		<div className="flex flex-col">
+			<p className="text-center text-gray-05 subhead-bold-22">오늘 날짜에 해당하는 할 일만</p>
+			<p className="text-center text-gray-05 subhead-bold-22">추가할 수 있어요.</p>
+		</div>
 		<ButtonAlert variant="primary" onClick={onConfirm}>
 			확인
 		</ButtonAlert>

--- a/src/pages/HomePage/ModalContentsAlert/TimerRestriction/TimerRestriction.tsx
+++ b/src/pages/HomePage/ModalContentsAlert/TimerRestriction/TimerRestriction.tsx
@@ -1,0 +1,13 @@
+import ButtonAlert from '../ButtonAlert/ButtonAlert';
+import { AlertModalProps } from '../types/index';
+
+const TimerRestriction = ({ onConfirm }: AlertModalProps) => (
+	<div className="flex h-[19.8rem] w-[47.2rem] flex-col gap-[3rem] rounded-[8px] bg-gray-bg-04 p-[3rem]">
+		<p className="text-center text-gray-05 subhead-bold-22">오늘 날짜에 해당하는 할 일만 타이머를 실행할 수 있어요.</p>
+		<ButtonAlert variant="primary" onClick={onConfirm}>
+			확인
+		</ButtonAlert>
+	</div>
+);
+
+export default TimerRestriction;

--- a/src/pages/HomePage/TooltipFriendInfo/TooltipFriendInfo.tsx
+++ b/src/pages/HomePage/TooltipFriendInfo/TooltipFriendInfo.tsx
@@ -43,8 +43,12 @@ const TooltipFriendInfo = ({ image, name, time, categoryName, isPlaying, isOnlin
 					<div className="flex w-[14.8rem] flex-col justify-center gap-[0.5rem]">
 						<p className="text-white body-semibold-16">{name}</p>
 						<div className="flex items-center justify-start gap-[0.8rem]">
-							<p className="text-gray-05 detail-reg-14">{categoryName || '카테고리 없음'}</p>
-							<LineIcon />
+							{isOnline && (
+								<>
+									<p className="text-gray-05 detail-reg-14">{categoryName}</p>
+									<LineIcon />
+								</>
+							)}
 							<p className={`detail-reg-14 ${isPlaying ? 'text-mint-01' : 'text-gray-05'}`}>{formattedTime}</p>
 						</div>
 					</div>

--- a/src/pages/HomePage/TooltipFriendInfo/TooltipFriendInfo.tsx
+++ b/src/pages/HomePage/TooltipFriendInfo/TooltipFriendInfo.tsx
@@ -41,11 +41,11 @@ const TooltipFriendInfo = ({ image, name, time, categoryName, isPlaying, isOnlin
 						)}
 					</div>
 					<div className="flex w-[14.8rem] flex-col justify-center gap-[0.5rem]">
-						<p className="text-white body-semibold-16">{name}</p>
+						<p className="truncate text-white body-semibold-16">{name}</p>
 						<div className="flex items-center justify-start gap-[0.8rem]">
-							{isOnline && (
+							{categoryName && (
 								<>
-									<p className="text-gray-05 detail-reg-14">{categoryName}</p>
+									<p className="max-w-[7.7rem] truncate text-gray-05 detail-reg-14">{categoryName}</p>
 									<LineIcon />
 								</>
 							)}

--- a/src/pages/TimerPage/Carousel/CarouselFriend.tsx
+++ b/src/pages/TimerPage/Carousel/CarouselFriend.tsx
@@ -65,8 +65,8 @@ const CarouselFriend = memo(function CarouselFriend({
 			</div>
 
 			{/* 이름 및 카테고리 표시 */}
-			<span className="text-white detail-semibold-14">{name}</span>
-			<span className="text-gray-04 detail-reg-12">{categoryName}</span>
+			<span className="w-full truncate text-center text-white detail-semibold-14">{name}</span>
+			<span className="w-full truncate text-center text-gray-04 detail-reg-12">{categoryName}</span>
 		</div>
 	);
 });

--- a/src/pages/TimerPage/MainTimer/TimerHeader/TimerHeader.tsx
+++ b/src/pages/TimerPage/MainTimer/TimerHeader/TimerHeader.tsx
@@ -25,8 +25,8 @@ const TimerHeader = ({ selectedTaskName, selectedTaskCategoryName, hasSelectedTa
 
 	return (
 		<header className="flex flex-col items-center gap-[0.4rem]">
-			<h1 className="text-white title-semibold-48">{selectedTaskName}</h1>
-			<h2 className="text-gray-04 head-bold-30">{selectedTaskCategoryName}</h2>
+			<h1 className="w-[120rem] truncate text-center text-white title-semibold-48">{selectedTaskName}</h1>
+			<h2 className="w-[80rem] truncate text-center text-gray-04 head-bold-30">{selectedTaskCategoryName}</h2>
 		</header>
 	);
 };

--- a/src/shared/components/BoxTodo/BoxTodo.tsx
+++ b/src/shared/components/BoxTodo/BoxTodo.tsx
@@ -128,7 +128,7 @@ const BoxTodo = ({
 
 	return (
 		<div
-			className={`group relative mt-[1rem] h-[9.5rem] w-[28rem] transform rounded-[8px] bg-gray-bg-01 p-[1.4rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle} ${clickStyle}`}
+			className={`group relative mt-[1rem] h-[9.5rem] w-[28rem] transform rounded-[8px] bg-gray-bg-01 px-[1.4rem] py-[1.2rem] transition-transform duration-300 hover:-translate-y-2 ${selectedStyle} ${clickStyle}`}
 			onClick={handleClickTodo}
 		>
 			<div className="flex flex-col justify-center">
@@ -173,7 +173,7 @@ const BoxTodo = ({
 						</Dropdown>
 					)}
 				</div>
-				<div className="ml-[0.8rem] mt-[0.7rem] flex flex-col gap-[0.2rem]">
+				<div className="ml-[0.8rem] mt-[0.6rem] flex flex-col gap-[0.2rem]">
 					<button
 						className={`flex max-w-max gap-[0.6rem] rounded-[0.3rem] pr-[0.2rem] ${activeCalendarTask ? 'bg-mint-01' : 'hover:bg-gray-bg-03'} ${clickable || isComplete ? 'pointer-events-none' : ''}`}
 						onClick={handleCalendarToggle}

--- a/src/shared/components/ModalContentsFriends/FriendsList/FriendsInfo/FriendInfo.tsx
+++ b/src/shared/components/ModalContentsFriends/FriendsList/FriendsInfo/FriendInfo.tsx
@@ -25,7 +25,7 @@ const FriendInfo = ({ friendsData }: FriendsInfoProp) => {
 						<div className="flex w-[40rem] flex-shrink-0">
 							<FriendUserProfile isConnecting={friend.isOnline} imgSrc={friend.imageUrl} />
 							<div className="ml-[2rem] flex flex-col justify-center">
-								<p className="text-white subhead-bold-20">{friend.name}</p>
+								<p className="w-[30rem] truncate text-white subhead-bold-20">{friend.name}</p>
 								<p className="text-gray-04 body-reg-16">{friend.email}</p>
 							</div>
 						</div>

--- a/src/shared/layout/Sidebar/Sidebar.tsx
+++ b/src/shared/layout/Sidebar/Sidebar.tsx
@@ -44,7 +44,7 @@ const Sidebar = () => {
 					/>
 				</button>
 
-				<section className="flex w-full flex-col items-center justify-center">
+				<section className="flex w-full flex-col items-center justify-center gap-[0.4rem]">
 					<button onClick={navigateAllowedService} className="relative flex w-full gap-[0.8rem]">
 						<hr
 							className={`h-[54px] w-[2px] rounded-r-[8px] ${pathName === ROUTES_CONFIG.allowedService.path ? 'bg-white' : 'border-transparent bg-transparent'}`}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #issue_number

## ✅ 작업 리스트

- [x] 홈페이지 친구리스트 +n원 텍스트 중심에 맞도록 위치 수정
- [x] 홈페이지 친구리스트 오프라인 친구도 등장하고, 내부 로직 수정
- [x] 할 일 카드 패딩값 수정
- [x] 허용서비스 세트가 없는 유저 대상으로 타이머시작 버튼 눌렀을 때 [그냥 시작하기], [허용 서비스 세트 만들기] 다이얼로그 띄우기
- [x] 오늘 할 일 카드 추가 버튼 클릭시, selectedDate 오늘 날짜가 되고 다른 날짜 클릭시 alert띄워주기
- [x] truncate 적용 필요한 부분 적용

## 🔧 작업 내용
### 홈페이지 친구리스트 오프라인 친구도 등장하고, 내부 로직 수정

기획과 논의하여 확정된 로직으로 변경하였습니다.
- 오프라인 친구도 등장. 그러나 우선순위는 온라인>오프라인이며 동일한 상태라면 타이머 시간 순으로 왼쪽에 위치합니다.
- 오프라인이지만 타이머를 돌린 친구 호버시 타이머 시간만 띄워주도록 변경.
- 친구 5명이하인 경우에는 +n원 등장 x

### truncate 적용 필요한 부분 적용
친구리스트 페이지, 홈페이지 카테고리·할 일 카드 이름, 홈페이지 친구리스트 등등  truncate 적용 필요한 부분 모두 적용했습니다.

### 허용서비스 세트가 없는 유저 대상으로 타이머시작 버튼 눌렀을 때 [그냥 시작하기], [허용 서비스 세트 만들기] 다이얼로그 띄우기
기존 허용서비스세트 get해오는 api 활용하여 length가 0이면 다이얼로그 띄워주도록 하였습니다. 그냥 시작 or 허용 서비스 세트 페이지로 이동 선택 가능

### 오늘 할 일 카드 추가 버튼 클릭시, selectedDate 오늘 날짜가 되고 다른 날짜 클릭시 alert띄워주기
어떤 날짜에서든 오늘 할 일 카드 추가 버튼 클릭시 오늘 날짜로 이동하며, 다른 날짜 클릭시 `TimerRestriction` alert를 띄워줍니다.

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

> 오늘 할 일 카드 추가 버튼 클릭시, selectedDate 오늘 날짜가 되고 다른 날짜 클릭시 alert띄워주기

https://github.com/user-attachments/assets/0c967cb8-1404-4d03-b291-2a242edddf63

> 허용서비스 세트가 없는 유저 대상으로 타이머시작 버튼 눌렀을 때 [그냥 시작하기], [허용 서비스 세트 만들기] 다이얼로그 띄우기


https://github.com/user-attachments/assets/44eea748-e04d-422f-8f62-84e92c24dd72





